### PR TITLE
Use manifest files when releasing

### DIFF
--- a/.github/workflows/ds3-release.yaml
+++ b/.github/workflows/ds3-release.yaml
@@ -9,9 +9,6 @@ env:
   # mod.
   STABLE_TAG_PREFIX_PREFIX: 'refs/tags/ds3-v4.0.'
 
-  # The minimum version of Archipelago known to work with our apworld.
-  REQUIRED_AP_VERSION: 0.6.6
-
 jobs:
   version:
     runs-on: ubuntu-latest
@@ -111,7 +108,7 @@ jobs:
         path: standard\DS3Randomizer.exe
         if-no-files-found: error
 
-  build-yaml:
+  build-ap:
     runs-on: ubuntu-latest
     needs: [version]
 
@@ -128,17 +125,36 @@ jobs:
       with:
         python-version: 3.11
 
+    # Do this locally here, but only commit it in the tag-server step so that if
+    # something else goes wrong during the release process we don't have
+    # mismatched versions.
+    - name: Set version
+      run: |
+        yq --inplace '.world_version = "${{ needs.version.outputs.version }}"' worlds/dark_souls_3/archipelago.json
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install pytest pytest-subtests pytest-xdist
         python ModuleUpdate.py --yes --force --append "WebHostLib/requirements.txt"
 
+    - name: Generate apworld
+      run: |
+        python Launcher.py 'Build APWorlds'
+        mv build/apworld/dark_souls_3.apworld dark_souls_3.apworld
+
     - name: Generate YAML
       run: |
         python Launcher.py 'Generate Template Options'
         mv 'Players/Templates/Dark Souls III.yaml' 'Dark Souls III Options Template.yaml'
-        yq --inplace '.requires.version = strenv(REQUIRED_AP_VERSION)' 'Dark Souls III Options Template.yaml'
+        export required_ap_version=$(yq .minimum_ap_version worlds/dark_souls_3/archipelago.json)
+        yq --inplace '.requires.version = strenv(required_ap_version)' 'Dark Souls III Options Template.yaml'
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: dark_souls_3.apworld
+        path: dark_souls_3.apworld
+        if-no-files-found: error
 
     - uses: actions/upload-artifact@v4
       with:
@@ -148,7 +164,7 @@ jobs:
 
   build-zip:
     runs-on: ubuntu-latest
-    needs: [version, build-mod, build-static, build-yaml]
+    needs: [version, build-mod, build-static, build-ap]
     env:
       dir: DS3 Archipelago ${{ needs.version.outputs.version }}
 
@@ -169,12 +185,6 @@ jobs:
 
     - run: unzip -d me3-windows me3-windows.zip
 
-    - name: Download Archipelago repo
-      run: |
-        curl -L "https://github.com/fswap/Archipelago/archive/refs/heads/main.tar.gz" | tar xz
-        cd Archipelago-*/worlds
-        zip -r ../../dark_souls_3.apworld dark_souls_3
-
     - name: Assemble Windows release
       run: |
         mkdir "$dir"
@@ -187,7 +197,6 @@ jobs:
         mv me3-windows/CHANGELOG.pdf "$dir/ME3-CHANGELOG.pdf"
         mv me3-windows/LICENSE-APACHE "$dir/ME3-LICENSE-APACHE"
         mv me3-windows/LICENSE-MIT "$dir/ME3-LICENSE-MIT"
-        mv dark_souls_3.apworld "$dir"
 
         # Windows-specific
         mv me3-windows/bin "$dir/bin"
@@ -197,6 +206,12 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: ds3_archipelago.dll
+        path: ${{ env.dir }}
+
+    - name: Download apworld
+      uses: actions/download-artifact@v4
+      with:
+        name: dark_souls_3.apworld
         path: ${{ env.dir }}
 
     - name: Download YAML
@@ -251,8 +266,14 @@ jobs:
         ref: main
         fetch-depth: 0
   
-    - run: git tag ds3-${{ needs.version.outputs.version }}
-    - run: git push --tag
+    - name: Set version
+      run: |
+        yq --inplace '.world_version = "${{ needs.version.outputs.version }}"' worlds/dark_souls_3/archipelago.json
+
+    - uses: EndBug/add-and-commit@v10
+      with:
+        message: Update Dark Souls III version
+        tag: ds3-${{ steps.version.outputs.version }}
 
   tag-static:
     runs-on: ubuntu-latest

--- a/.github/workflows/sdt-release.yaml
+++ b/.github/workflows/sdt-release.yaml
@@ -4,10 +4,6 @@ on:
   push:
     tags: ['sdt-v*.*.*']
 
-env:
-  # The minimum version of Archipelago known to work with our apworld.
-  REQUIRED_AP_VERSION: 0.6.6
-
 jobs:
   version:
     runs-on: ubuntu-latest
@@ -107,7 +103,7 @@ jobs:
         path: standard\SekiroRandomizer.exe
         if-no-files-found: error
 
-  build-yaml:
+  build-ap:
     runs-on: ubuntu-latest
     needs: [version]
 
@@ -124,17 +120,36 @@ jobs:
       with:
         python-version: 3.11
 
+    # Do this locally here, but only commit it in the tag-server step so that if
+    # something else goes wrong during the release process we don't have
+    # mismatched versions.
+    - name: Set version
+      run: |
+        yq --inplace '.world_version = "${{ needs.version.outputs.version }}"' worlds/sekiro/archipelago.json
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install pytest pytest-subtests pytest-xdist
         python ModuleUpdate.py --yes --force --append "WebHostLib/requirements.txt"
 
+    - name: Generate apworld
+      run: |
+        python Launcher.py 'Build APWorlds'
+        mv build/apworld/sekiro.apworld sekiro.apworld
+
     - name: Generate YAML
       run: |
         python Launcher.py 'Generate Template Options'
         mv 'Players/Templates/Sekiro Shadows Die Twice.yaml' 'Sekiro Options Template.yaml'
-        yq --inplace '.requires.version = strenv(REQUIRED_AP_VERSION)' 'Sekiro Options Template.yaml'
+        export required_ap_version=$(yq .minimum_ap_version worlds/sekiro/archipelago.json)
+        yq --inplace '.requires.version = strenv(required_ap_version)' 'Sekiro Options Template.yaml'
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: sekiro.apworld
+        path: sekiro.apworld
+        if-no-files-found: error
 
     - uses: actions/upload-artifact@v4
       with:
@@ -144,7 +159,7 @@ jobs:
 
   build-zip:
     runs-on: ubuntu-latest
-    needs: [version, build-mod, build-static, build-yaml]
+    needs: [version, build-mod, build-static, build-ap]
     env:
       dir: Sekiro Archipelago ${{ needs.version.outputs.version }}
 
@@ -165,12 +180,6 @@ jobs:
 
     - run: unzip -d me3-windows me3-windows.zip
 
-    - name: Download Archipelago repo
-      run: |
-        curl -L "https://github.com/fswap/Archipelago/archive/refs/heads/sekiro.tar.gz" | tar xz
-        cd Archipelago-*/worlds
-        zip -r ../../sekiro.apworld sekiro
-
     - name: Assemble Windows release
       run: |
         mkdir "$dir"
@@ -182,7 +191,6 @@ jobs:
         mv me3-windows/CHANGELOG.pdf "$dir/ME3-CHANGELOG.pdf"
         mv me3-windows/LICENSE-APACHE "$dir/ME3-LICENSE-APACHE"
         mv me3-windows/LICENSE-MIT "$dir/ME3-LICENSE-MIT"
-        mv sekiro.apworld "$dir"
 
         # Windows-specific
         mv me3-windows/bin "$dir/bin"
@@ -192,6 +200,12 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: sdt_archipelago.dll
+        path: ${{ env.dir }}
+
+    - name: Download apworld
+      uses: actions/download-artifact@v4
+      with:
+        name: sekiro.apworld
         path: ${{ env.dir }}
 
     - name: Download YAML
@@ -246,8 +260,14 @@ jobs:
         ref: main
         fetch-depth: 0
   
-    - run: git tag sdt-${{ needs.version.outputs.version }}
-    - run: git push --tag
+    - name: Set version
+      run: |
+        yq --inplace '.world_version = "${{ needs.version.outputs.version }}"' worlds/sekiro/archipelago.json
+
+    - uses: EndBug/add-and-commit@v10
+      with:
+        message: Update Sekiro version
+        tag: sdt-${{ steps.version.outputs.version }}
 
   tag-static:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This also uses the built-in Archipelago launcher's apworld builder, which makes some modifications to the manifest files that we don't want to have to do manually.