### PR TITLE
Fix typo in set_notice: second call should be set_is_notice_dialog

### DIFF
--- a/crates/sdt-archipelago/src/core.rs
+++ b/crates/sdt-archipelago/src/core.rs
@@ -389,6 +389,6 @@ fn set_notice(id: ItemId, notice_log: bool, notice_dialog: bool) -> Result<(bool
         .into_dyn();
     let previous = (row.is_notice_log(), row.is_notice_dialog());
     row.set_is_notice_log(notice_log);
-    row.set_is_notice_log(notice_dialog);
+    row.set_is_notice_dialog(notice_dialog);
     Ok(previous)
 }


### PR DESCRIPTION
The function takes both notice_log and notice_dialog parameters and saves/restores both, but the second setter call was a copy-paste of the first and wrote set_is_notice_log twice.