### PR TITLE
Fixing launch bats to run in current directory

### DIFF
--- a/crates/ds3-archipelago/release/launch-ds3.bat
+++ b/crates/ds3-archipelago/release/launch-ds3.bat
@@ -1,2 +1,3 @@
+cd /D "%~dp0"
 chcp 65001
 .\bin\me3.exe launch -p me3-config.me3

--- a/crates/sdt-archipelago/release/launch-sekiro.bat
+++ b/crates/sdt-archipelago/release/launch-sekiro.bat
@@ -1,2 +1,3 @@
+cd /D "%~dp0"
 chcp 65001
 .\bin\me3.exe launch -p me3-config.me3


### PR DESCRIPTION
Make commands run from the current directory the bat file is in.