### PR TITLE
Bump archipelago_rs to 3.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -249,7 +249,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -390,7 +390,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -455,6 +455,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -496,7 +505,7 @@ dependencies = [
  "bitfield",
  "cxx-stl",
  "encoding_rs",
- "fromsoftware-shared",
+ "fromsoftware-shared 0.13.0",
  "pelite",
  "thiserror 1.0.69",
  "vtable-rs",
@@ -511,7 +520,7 @@ dependencies = [
  "bitflags 2.11.1",
  "darksouls3",
  "fromsoftware-extra-shared",
- "fromsoftware-shared",
+ "fromsoftware-shared 0.13.0",
  "ilhook",
  "pelite",
  "thiserror 1.0.69",
@@ -602,7 +611,7 @@ dependencies = [
  "bincode",
  "darksouls3",
  "darksouls3-extra",
- "fromsoftware-shared",
+ "fromsoftware-shared 0.13.0",
  "hudhook",
  "ilhook",
  "log",
@@ -628,6 +637,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "eldenring"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f98d635e24da261a5972a2f74cb453140acf31c23216d1b27744e5de0727108"
+dependencies = [
+ "bitfield",
+ "bitflags 2.11.1",
+ "encoding_rs",
+ "fromsoftware-shared 0.14.0",
+ "fromsoftware-shared-stl",
+ "glam",
+ "num_enum",
+ "pelite",
+ "thiserror 1.0.69",
+ "vtable-rs",
+ "windows 0.61.3",
+]
+
+[[package]]
+name = "eldenring-archipelago"
+version = "0.1.0"
+dependencies = [
+ "archipelago_rs",
+ "eldenring",
+ "er-codec",
+ "er-semver",
+ "fromsoftware-shared 0.14.0",
+ "retour",
+ "serde",
+ "serde_json",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
+ "windows 0.61.3",
+]
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -641,6 +687,14 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "er-codec"
+version = "0.1.0"
+
+[[package]]
+name = "er-semver"
+version = "0.1.0"
 
 [[package]]
 name = "errno"
@@ -740,13 +794,30 @@ source = "git+https://github.com/vswarte/fromsoftware-rs#893cdd376d58b30cefb0d09
 dependencies = [
  "bitflags 2.11.1",
  "from-singleton",
- "fromsoftware-shared-macros",
+ "fromsoftware-shared-macros 0.13.0",
  "glam",
  "pelite",
  "thiserror 1.0.69",
  "undname",
  "vtable-rs",
  "windows 0.54.0",
+]
+
+[[package]]
+name = "fromsoftware-shared"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e2a3db947909eb9fff3637bc882683f0b0dadee9884ea24ceb107525ad19d96"
+dependencies = [
+ "bitflags 2.11.1",
+ "from-singleton",
+ "fromsoftware-shared-macros 0.14.0",
+ "glam",
+ "pelite",
+ "thiserror 1.0.69",
+ "undname",
+ "vtable-rs",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -759,6 +830,24 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "fromsoftware-shared-macros"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e83f4050cdfb1847ee0d31385f53dc197bf414b39abc9d92483f571fb9e750b"
+dependencies = [
+ "inflections",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "fromsoftware-shared-stl"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfeff057215d7f565737d8ee24516b2a77dff92966626fe42e0f36e9a289f2c5"
 
 [[package]]
 name = "fs_extra"
@@ -958,7 +1047,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "windows 0.62.2",
- "windows-numerics",
+ "windows-numerics 0.3.1",
 ]
 
 [[package]]
@@ -1124,6 +1213,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libudis86-sys"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139bbf9ddb1bfc90c1ac64dd2923d9c957cd433cee7315c018125d72ab08a6b0"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1143,6 +1242,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "matchers"
@@ -1175,6 +1283,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e53debba6bda7a793e5f99b8dacf19e626084f525f7829104ba9898f367d85ff"
 
 [[package]]
+name = "mmap-fixed-fixed"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0681853891801e4763dc252e843672faf32bcfee27a0aa3b19733902af450acc"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1204,6 +1322,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1216,6 +1343,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1317,7 +1466,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1399,6 +1548,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -1545,6 +1703,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "region"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6b6ebd13bc009aef9cd476c1310d49ac354d36e240cf1bd753290f3dc7199a7"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+ "mach2",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "retour"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9af44d40e2400b44d491bfaf8eae111b09f23ac4de6e92728e79d93e699c527"
+dependencies = [
+ "cfg-if",
+ "generic-array",
+ "libc",
+ "libudis86-sys",
+ "mmap-fixed-fixed",
+ "once_cell",
+ "region",
+ "slice-pool2",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1671,7 +1857,7 @@ dependencies = [
  "anyhow",
  "archipelago_rs",
  "bincode",
- "fromsoftware-shared",
+ "fromsoftware-shared 0.13.0",
  "hudhook",
  "ilhook",
  "log",
@@ -1718,7 +1904,7 @@ dependencies = [
  "bitflags 2.11.1",
  "cxx-stl",
  "encoding_rs",
- "fromsoftware-shared",
+ "fromsoftware-shared 0.13.0",
  "pelite",
  "thiserror 1.0.69",
  "vtable-rs",
@@ -1732,7 +1918,7 @@ source = "git+https://github.com/nex3/fromsoftware-extra?branch=sekiro-save#4f83
 dependencies = [
  "bitflags 2.11.1",
  "fromsoftware-extra-shared",
- "fromsoftware-shared",
+ "fromsoftware-shared 0.13.0",
  "ilhook",
  "log",
  "pelite",
@@ -1844,6 +2030,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shared"
 version = "0.0.0"
 dependencies = [
@@ -1853,7 +2048,7 @@ dependencies = [
  "bitflags 2.11.1",
  "chrono",
  "clipboard-win",
- "fromsoftware-shared",
+ "fromsoftware-shared 0.13.0",
  "hudhook",
  "imgui",
  "imgui-sys",
@@ -1906,6 +2101,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
+name = "slice-pool2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a3d689654af89bdfeba29a914ab6ac0236d382eb3b764f7454dde052f2821f8"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1939,6 +2140,12 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "syn"
@@ -2056,6 +2263,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+dependencies = [
+ "indexmap 2.14.0",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2063,7 +2300,32 @@ checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2073,6 +2335,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
 ]
 
 [[package]]
@@ -2082,11 +2356,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
+ "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "sharded-slab",
+ "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -2170,6 +2448,12 @@ dependencies = [
  "parking_lot",
  "serde",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"
@@ -2364,14 +2648,36 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections 0.2.0",
+ "windows-core 0.61.2",
+ "windows-future 0.2.1",
+ "windows-link 0.1.3",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
- "windows-collections",
+ "windows-collections 0.3.2",
  "windows-core 0.62.2",
- "windows-future",
- "windows-numerics",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -2395,15 +2701,39 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
+ "windows-link 0.2.1",
  "windows-result 0.4.1",
- "windows-strings",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+ "windows-threading 0.1.0",
 ]
 
 [[package]]
@@ -2413,8 +2743,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
  "windows-core 0.62.2",
- "windows-link",
- "windows-threading",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -2441,9 +2771,25 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+]
 
 [[package]]
 name = "windows-numerics"
@@ -2452,7 +2798,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
  "windows-core 0.62.2",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2466,11 +2812,29 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -2479,7 +2843,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2506,7 +2870,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2531,7 +2895,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -2544,11 +2908,20 @@ dependencies = [
 
 [[package]]
 name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2646,6 +3019,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,6 +79,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "archipelago_rs"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f824b6faac01bc5bc1c4abfbe7fe8e81463033d0ebc63d7c9fa43d084695340a"
+dependencies = [
+ "bitflags 2.11.1",
+ "log",
+ "native-tls",
+ "oneshot",
+ "rand 0.10.1",
+ "rustls",
+ "sanitise-file-name",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "serde_with",
+ "smol",
+ "thiserror 2.0.18",
+ "try-specialize",
+ "tungstenite",
+ "ustr",
+ "webpki-roots",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -607,7 +632,7 @@ name = "ds3-archipelago"
 version = "4.0.2"
 dependencies = [
  "anyhow",
- "archipelago_rs",
+ "archipelago_rs 3.0.1",
  "bincode",
  "darksouls3",
  "darksouls3-extra",
@@ -659,7 +684,7 @@ dependencies = [
 name = "eldenring-archipelago"
 version = "0.1.0"
 dependencies = [
- "archipelago_rs",
+ "archipelago_rs 2.1.1",
  "eldenring",
  "er-codec",
  "er-semver",
@@ -1855,7 +1880,7 @@ name = "sdt-archipelago"
 version = "1.0.0-alpha.8"
 dependencies = [
  "anyhow",
- "archipelago_rs",
+ "archipelago_rs 3.0.1",
  "bincode",
  "fromsoftware-shared 0.13.0",
  "hudhook",
@@ -2043,7 +2068,7 @@ name = "shared"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "archipelago_rs",
+ "archipelago_rs 3.0.1",
  "backtrace",
  "bitflags 2.11.1",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,12 @@ members = [
     "crates/ds3-archipelago",
     "crates/sdt-archipelago",
     "crates/shared",
+    # --- Elden Ring (DRAFT) -------------------------------------------------
+    # Alaric's Phase-5 ER runtime client + its two pure-logic crates.
+    # Not yet converged onto `shared`; see the PR description for the WIP list.
+    "crates/eldenring-archipelago",
+    "crates/er-codec",
+    "crates/er-semver",
 ]
 
 [workspace.package]
@@ -56,4 +62,3 @@ sekiro = { git = "https://github.com/vswarte/fromsoftware-rs" }
 # fromsoftware-extra-shared = { path = "../fromsoftware-extra/crates/shared" }
 # darksouls3-extra = { path = "../fromsoftware-extra/crates/darksouls3" }
 # sekiro-extra = { path = "../fromsoftware-extra/crates/sekiro" }
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ repository = "https://github.com/fswap/fromsoftware-archipelago"
 
 [workspace.dependencies]
 anyhow = "1.0.102"
-archipelago_rs = "2.1.1"
+archipelago_rs = "3.0.1"
 bincode = "2.0.0"
 fromsoftware-shared = { git = "https://github.com/vswarte/fromsoftware-rs" }
 fromsoftware-extra-shared = { git = "https://github.com/nex3/fromsoftware-extra", branch = "sekiro-save" }

--- a/crates/eldenring-archipelago/Cargo.toml
+++ b/crates/eldenring-archipelago/Cargo.toml
@@ -1,0 +1,60 @@
+[package]
+name = "eldenring-archipelago"
+version = "0.1.0"
+edition = "2021"
+description = "ER Archipelago runtime client (Rust spike). The injected cdylib: DllMain entry, AddItemFunc detour, ParamBase walk via fromsoftware-rs, CSEventFlagMan reporting. Pure logic comes from er-codec + er-semver."
+license = "MIT"
+
+[lib]
+# Injected DLL. (On non-Windows hosts this still builds — the in-process modules are cfg'd out —
+# so CI can typecheck the crate alongside the pure-logic crates.)
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+er-codec = { path = "../er-codec" }
+er-semver = { path = "../er-semver" }
+
+# Windows-only, in-process dependencies. Target-gated so `cargo build`/`test` works on Linux/macOS.
+# Versions are indicative — pin against fswap's workspace + crates.io at spike time (see SPEC §8).
+[target.'cfg(windows)'.dependencies]
+# Typed game bindings: SoloParamRepository / CSEventFlagMan / CSFieldArea / inventory / params.
+# Replaces er_hooks.h + er_singletons.h + the hand-rolled param walk.
+eldenring = "0.14"            # vswarte/fromsoftware-rs
+fromsoftware-shared = "0.14"  # FD4 singleton finder + shared structures
+# Inline detour for AddItemFunc (Phase 3). OPTIONAL + behind the `detour` feature: retour's
+# `static-detour` needs NIGHTLY, but fromsoftware-rs pins stable (its rust-toolchain.toml is
+# `channel = "stable"`), so Phase 3 implements detour.rs with retour's stable `GenericDetour`.
+# Off-by-default keeps the Phase-1 spike building on stable.
+retour = { version = "0.3", optional = true }
+# Win32 surface (GetModuleHandleW for the module base). Only detour.rs uses it today, so it rides
+# the same feature. Pinned 0.61 to match eldenring 0.14 (avoids two `windows` versions in the tree).
+windows = { version = "0.61", features = ["Win32_Foundation", "Win32_System_LibraryLoader", "Win32_System_Threading", "Win32_System_Console"], optional = true }
+# Logging (replaces spdlog): tracing + a non-blocking file sink (tracing-appender).
+tracing = "0.1"
+tracing-subscriber = "0.3"
+tracing-appender = "0.2"
+# JSON config / slot_data (replaces nlohmann/json).
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+# AP network protocol (Phase 4). nex3's archipelago_rs is the crate fswap's clients use. It is
+# POLL-based (Connection::update), so it runs on the worker thread with NO async runtime. Default
+# features pull rustls + native-tls (the crate tries rustls first, falls back to native-tls, then
+# plain ws). Off-by-default `net` feature.
+archipelago_rs = { version = "2.1.1", optional = true }
+
+[features]
+# `detour` (the Phase-3 AddItemFunc hook) is now on retour's STABLE GenericDetour, so it builds on
+# stable and is enabled by default. Build the lean Phase-1-only cdylib (no retour/windows) with
+# `--no-default-features`.
+# Phase 4 is compile-green, so `net` joins the default build (like `detour` did after Phase 3).
+default = ["detour", "net"]
+detour = ["dep:retour", "dep:windows"]
+# Phase 4 AP networking. Implies `detour` (server grants reuse the detour trampoline + the
+# inventory pointer it captures). NOT in `default` yet — enable with `--features net` until the
+# Windows build is green, then promote to default like `detour` was.
+net = ["detour", "dep:archipelago_rs"]
+
+[lints.rust]
+# Unlike the pure crates, this one needs `unsafe` for FFI/detours — but only inside the
+# clearly-marked in-process modules.
+unsafe_code = "warn"

--- a/crates/eldenring-archipelago/src/game/console.rs
+++ b/crates/eldenring-archipelago/src/game/console.rs
@@ -60,7 +60,9 @@ fn reader_thread() {
     let conin = match OpenOptions::new().read(true).open("CONIN$") {
         Ok(f) => f,
         Err(e) => {
-            say(&format!("console: cannot open CONIN$ ({e}); input disabled"));
+            say(&format!(
+                "console: cannot open CONIN$ ({e}); input disabled"
+            ));
             return;
         }
     };
@@ -105,13 +107,20 @@ fn exec(cmd: &str) {
                 say(&format!(
                     "setflag {flag} = {} -> {}",
                     on as u8,
-                    if ok { "ok" } else { "holder not ready (not in world?)" }
+                    if ok {
+                        "ok"
+                    } else {
+                        "holder not ready (not in world?)"
+                    }
                 ));
             }
             _ => say("usage: /setflag <id> <0|1>"),
         },
         ["/getflag", id] => match id.parse::<u32>() {
-            Ok(flag) => say(&format!("getflag {flag} = {}", flags::get_event_flag(flag) as u8)),
+            Ok(flag) => say(&format!(
+                "getflag {flag} = {}",
+                flags::get_event_flag(flag) as u8
+            )),
             Err(_) => say("usage: /getflag <id>"),
         },
         ["/region"] => match flags::play_region_id() {
@@ -122,7 +131,11 @@ fn exec(cmd: &str) {
             let ok = flags::try_set_event_flag(76996, true);
             say(&format!(
                 "/kill -> set DeathLink kill flag 76996 ({})",
-                if ok { "ok" } else { "holder not ready (not in world?)" }
+                if ok {
+                    "ok"
+                } else {
+                    "holder not ready (not in world?)"
+                }
             ));
         }
         ["/help"] => say("commands: /setflag <id> <0|1>, /getflag <id>, /region, /kill, /help"),

--- a/crates/eldenring-archipelago/src/game/console.rs
+++ b/crates/eldenring-archipelago/src/game/console.rs
@@ -1,0 +1,139 @@
+//! Debug console (Windows) — ports the C++ client's interactive command window that the file-logging
+//! Rust client dropped. Allocates a console and accepts `/setflag`, `/getflag`, `/region`, `/kill`,
+//! `/help`. Commands are PARSED on a dedicated stdin thread and EXECUTED on the FrameBegin game tick
+//! (event-flag access is game-thread-only — same rule as features.rs), with results printed back.
+//!
+//! Behind the `detour` feature (default) because it needs the `windows` crate (AllocConsole + the
+//! Win32_System_Console surface). Lean `--no-default-features` builds compile it out.
+
+#![allow(dead_code)]
+
+use std::collections::VecDeque;
+use std::fs::{File, OpenOptions};
+use std::io::{BufRead, BufReader, Write};
+use std::sync::{Mutex, OnceLock};
+
+use super::flags;
+
+/// Lines typed at the console, parsed on the stdin thread, drained on the game tick.
+fn queue() -> &'static Mutex<VecDeque<String>> {
+    static Q: OnceLock<Mutex<VecDeque<String>>> = OnceLock::new();
+    Q.get_or_init(|| Mutex::new(VecDeque::new()))
+}
+
+/// The console output device (CONOUT$), opened once. `None` if it couldn't be opened.
+fn conout() -> &'static Mutex<Option<File>> {
+    static O: OnceLock<Mutex<Option<File>>> = OnceLock::new();
+    O.get_or_init(|| Mutex::new(OpenOptions::new().write(true).open("CONOUT$").ok()))
+}
+
+/// Print a line to the console AND mirror it into the trace log (so console output is captured too).
+fn say(s: &str) {
+    if let Ok(mut g) = conout().lock() {
+        if let Some(f) = g.as_mut() {
+            let _ = writeln!(f, "{s}");
+        }
+    }
+    tracing::info!("[console] {s}");
+}
+
+/// Called once from `game::init` (worker thread): allocate a console + spawn the stdin reader.
+pub fn init() {
+    use windows::Win32::System::Console::AllocConsole;
+    // Best-effort: if the loader already gave the process a console, AllocConsole returns Err and we
+    // simply reuse the existing one via CONOUT$/CONIN$.
+    unsafe {
+        let _ = AllocConsole();
+    }
+    say("eldenring-ap console ready. Commands:");
+    say("  /setflag <id> <0|1>   set or clear an event flag");
+    say("  /getflag <id>         read an event flag");
+    say("  /region               print the player's PlayRegionId");
+    say("  /kill                 set DeathLink kill flag 76996 (die, keep runes)");
+    say("  /help                 this list");
+    std::thread::spawn(reader_thread);
+}
+
+/// Blocking stdin loop on a dedicated thread. Reads from CONIN$ directly: after AllocConsole,
+/// `std::io::stdin()` may still bind the old (absent) handle, so open the console input device.
+fn reader_thread() {
+    let conin = match OpenOptions::new().read(true).open("CONIN$") {
+        Ok(f) => f,
+        Err(e) => {
+            say(&format!("console: cannot open CONIN$ ({e}); input disabled"));
+            return;
+        }
+    };
+    let mut reader = BufReader::new(conin);
+    let mut line = String::new();
+    loop {
+        line.clear();
+        match reader.read_line(&mut line) {
+            Ok(0) => break, // console closed (EOF)
+            Ok(_) => {
+                let cmd = line.trim().to_string();
+                if !cmd.is_empty() {
+                    queue().lock().unwrap().push_back(cmd);
+                }
+            }
+            Err(_) => break,
+        }
+    }
+}
+
+/// Called from `game::tick` (game thread): drain + execute queued commands. Event-flag reads/writes
+/// are only safe on this thread, so every command effect runs here.
+pub fn tick() {
+    let cmds: Vec<String> = {
+        let mut q = queue().lock().unwrap();
+        if q.is_empty() {
+            return;
+        }
+        q.drain(..).collect()
+    };
+    for cmd in cmds {
+        exec(&cmd);
+    }
+}
+
+fn exec(cmd: &str) {
+    let p: Vec<&str> = cmd.split_whitespace().collect();
+    match p.as_slice() {
+        ["/setflag", id, val] => match (id.parse::<u32>(), parse_bool(val)) {
+            (Ok(flag), Some(on)) => {
+                let ok = flags::try_set_event_flag(flag, on);
+                say(&format!(
+                    "setflag {flag} = {} -> {}",
+                    on as u8,
+                    if ok { "ok" } else { "holder not ready (not in world?)" }
+                ));
+            }
+            _ => say("usage: /setflag <id> <0|1>"),
+        },
+        ["/getflag", id] => match id.parse::<u32>() {
+            Ok(flag) => say(&format!("getflag {flag} = {}", flags::get_event_flag(flag) as u8)),
+            Err(_) => say("usage: /getflag <id>"),
+        },
+        ["/region"] => match flags::play_region_id() {
+            Some(r) => say(&format!("play_region_id = {r}")),
+            None => say("play_region_id = (not in world)"),
+        },
+        ["/kill"] => {
+            let ok = flags::try_set_event_flag(76996, true);
+            say(&format!(
+                "/kill -> set DeathLink kill flag 76996 ({})",
+                if ok { "ok" } else { "holder not ready (not in world?)" }
+            ));
+        }
+        ["/help"] => say("commands: /setflag <id> <0|1>, /getflag <id>, /region, /kill, /help"),
+        _ => say(&format!("unknown command: '{cmd}' (try /help)")),
+    }
+}
+
+fn parse_bool(s: &str) -> Option<bool> {
+    match s {
+        "1" | "on" | "true" | "ON" | "TRUE" => Some(true),
+        "0" | "off" | "false" | "OFF" | "FALSE" => Some(false),
+        _ => None,
+    }
+}

--- a/crates/eldenring-archipelago/src/game/deathlink.rs
+++ b/crates/eldenring-archipelago/src/game/deathlink.rs
@@ -1,0 +1,268 @@
+//! Wave D — **DeathLink**. Rust port of the DeathLink mechanic from
+//! `ArchipelagoInterface.cpp` (`set_bounced_handler` ~536-562 INCOMING, `sendDeathLink` ~620-630
+//! OUTGOING, and the `DeathLink` tag pushed in `ConnectSlot` ~309) onto archipelago_rs 2.1.1.
+//!
+//! ## What this module owns vs. what's a hole
+//! The **network protocol** side is COMPLETE and correct against archipelago_rs (verified against the
+//! vendored crate under `third_party/archipelago_rs`):
+//!   * INCOMING: `net.rs` matches `ap::Event::DeathLink { source, cause, .. }` and calls
+//!     `on_death_link_event(..)`, which (after the self-source guard) latches a "kill pending" flag.
+//!   * OUTGOING: the game tick detects a LOCAL death (`poll_outgoing_death`) and latches a
+//!     "send pending" flag; `net.rs` drains it with `take_pending_outgoing()` and calls
+//!     `client.death_link(DeathLinkOptions)`.
+//!   * TAG: `net.rs` adds `ap::tags::DEATH_LINK` to `ConnectionOptions::tags(..)` iff `is_enabled()`.
+//!
+//! The **two game-memory touchpoints** are honest `// RE:` stubs — the ER kill mechanism was never
+//! implemented (C++ `GameHook.cpp::manageDeathLink()` is a stub for ER), and this client has no
+//! player-HP / death-state accessor yet (only `play_region_id`, see flags.rs). Both stubs carry a
+//! Cheat-Engine worksheet in their doc comment. Wiring this module lets the protocol go live now;
+//! Alaric fills `kill_player()` and `read_local_death()` in a CE session.
+//!
+//! ## Thread rule (inherited from features.rs / net.rs)
+//! NAME/event decisions run on the NET thread and only LATCH an AtomicBool; every game-memory read
+//! (death detection) and write (the kill) happens on the FrameBegin TICK. The net thread never
+//! touches game memory; the game thread never touches the socket. Two atomics bridge the two
+//! directions — no locks, no allocation on the hot path.
+
+#![allow(dead_code)] // handlers/stubs are wired ahead of the RE fill-in
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use super::flags;
+
+use eldenring::cs::{CSChrDataModule, WorldChrMan};
+use fromsoftware_shared::FromStatic;
+
+// =================================================================================================
+// State — three atomics. `ENABLED` is set once at connect (slot_data); the two latches bridge the
+// net<->game threads (Release on the producer, Acquire on the consumer so the latch publishes
+// cleanly across the thread boundary).
+// =================================================================================================
+
+/// True when the slot has DeathLink on (`options.death_link`). Read by net.rs to decide whether to
+/// add the tag and whether to act on events; read by the tick to decide whether to poll for a local
+/// death. Set once at connect via `configure_from_slot_data`.
+static ENABLED: AtomicBool = AtomicBool::new(false);
+
+/// INCOMING latch: an `Event::DeathLink` arrived (and passed the self-source guard) on the net
+/// thread; the game tick must kill the player once in-world. Mirrors the C++ `deathLinkData = true`.
+static KILL_PENDING: AtomicBool = AtomicBool::new(false);
+
+/// OUTGOING latch: the game tick detected the LOCAL player just died; the net thread must Bounce a
+/// DeathLink. Mirrors the C++ `sendDeathLink()` call site.
+static SEND_PENDING: AtomicBool = AtomicBool::new(false);
+
+/// Edge-detect state for `poll_outgoing_death` (game thread only, so a plain `static mut`-free
+/// AtomicBool is plenty): tracks whether we were already dead last tick, so a single death produces
+/// exactly one outgoing DeathLink rather than one per frame while the death screen is up.
+static WAS_DEAD: AtomicBool = AtomicBool::new(false);
+
+// =================================================================================================
+// Config (net thread, at connect).
+// =================================================================================================
+
+/// Net thread: enable/disable DeathLink for this slot.
+pub fn set_enabled(on: bool) {
+    ENABLED.store(on, Ordering::Relaxed);
+}
+
+/// True if DeathLink is on for this slot. net.rs gates the tag + event handling on this; the tick
+/// gates `poll_outgoing_death` on it.
+pub fn is_enabled() -> bool {
+    ENABLED.load(Ordering::Relaxed)
+}
+
+/// Net thread, at connect: read `options.death_link` out of slot_data and set `ENABLED`. Tolerant of
+/// the int-or-bool encoding the apworld uses for booleans (e.g. `enable_dlc` ships as int 0/1, not a
+/// JSON bool — see net.rs's parse of it), so a `0`/`1` integer, a real bool, or an absent key all
+/// resolve correctly (absent => off). Mirrors the `GameHook->dIsDeathLink` config read.
+pub fn configure_from_slot_data(sd: &serde_json::Value) {
+    // Reset the per-session latches first so a reconnect can't carry a stale kill/send across.
+    KILL_PENDING.store(false, Ordering::Relaxed);
+    SEND_PENDING.store(false, Ordering::Relaxed);
+    WAS_DEAD.store(false, Ordering::Relaxed);
+
+    let on = sd
+        .pointer("/options/death_link")
+        .map(|v| v.as_bool().unwrap_or_else(|| v.as_i64().unwrap_or(0) != 0))
+        .unwrap_or(false);
+    set_enabled(on);
+    if on {
+        tracing::info!("AP: DeathLink ENABLED for this slot");
+    } else {
+        tracing::debug!("AP: DeathLink off for this slot");
+    }
+}
+
+// =================================================================================================
+// INCOMING — net thread latches, game tick kills.
+// =================================================================================================
+
+/// Net thread: called from the `ap::Event::DeathLink` arm in net.rs. `source` is the player who
+/// died, `cause` the (optional) flavour text. Latches a kill for the game tick unless the death is
+/// OURS (the server echoes our own DeathLink back; killing ourselves for our own death would loop).
+///
+/// `our_slot` is the local slot name net.rs already has (`cfg.slot` / slot_data `slot`); the C++
+/// compared `data["source"] != Core->pSlotName` for exactly this self-suppression.
+pub fn on_death_link_event(source: &str, cause: Option<&str>, our_slot: &str) {
+    if !is_enabled() {
+        return; // tag wasn't added; shouldn't fire, but stay inert if it does
+    }
+    if !our_slot.is_empty() && source == our_slot {
+        tracing::debug!("AP: ignoring our own DeathLink echo (source {source})");
+        return;
+    }
+    let cause = cause.unwrap_or("???");
+    tracing::info!("AP: DeathLink received — died by the hands of {source} : {cause}");
+    // C++ also showBanner(message); the native-banner path is a separate (parked) feature here, so
+    // we only latch the kill. If/when the banner lands, enqueue it from THIS line.
+    KILL_PENDING.store(true, Ordering::Release);
+}
+
+/// Game thread (called from this module's `tick`): if a kill is pending and the player is in-world,
+/// attempt it. Clears the latch only on a SUCCESSFUL kill, so a kill latched while on a menu / load
+/// screen retries on the next in-world tick instead of being lost (matches the grace-flush retry
+/// discipline in features.rs).
+pub fn tick() {
+    if !is_enabled() {
+        return;
+    }
+    drive_incoming_kill();
+    poll_outgoing_death();
+}
+
+fn drive_incoming_kill() {
+    if !KILL_PENDING.load(Ordering::Acquire) {
+        return;
+    }
+    if !flags::in_world() {
+        return; // not placed yet — keep the latch, retry next tick
+    }
+    if kill_player() {
+        KILL_PENDING.store(false, Ordering::Release);
+        tracing::info!("AP: DeathLink applied — local player killed");
+    } else {
+        // kill_player is still a RE stub: log ONCE per latch so we don't spam every frame while the
+        // hole is open. The latch stays set; once the RE lands it'll succeed and clear.
+        if KILL_LOGGED.swap(true, Ordering::Relaxed) == false {
+            tracing::warn!(
+                "AP: DeathLink kill requested but kill_player() is an unfilled RE stub — \
+                 player NOT killed (see deathlink.rs kill_player worksheet)"
+            );
+        }
+    }
+}
+
+static KILL_LOGGED: AtomicBool = AtomicBool::new(false);
+
+// =================================================================================================
+// Game-memory touchpoint — the player current-HP cell, reached through the SAME typed chain
+// flags.rs uses for `play_region_id` (anchor = WorldChrMan.main_player). Filled from the validated
+// Hexington CE table (eldenring_all-in-one_Hexinton-v6.0_ce7.5.ct) reconciled against the typed
+// `eldenring 0.14` bindings (docs.rs), so we walk named struct fields rather than raw offsets.
+//
+// CE "HP" entry (ct lines 3685-3698 / dup 4963-4975): Address=WorldChrMan,
+//   Offsets (CE reads innermost-LAST) = [138, 0, 190, 0*10, LocalPlayerOffset].
+//   LocalPlayerOffset = 0x10EF8 (ct line 430) is WorldChrMan.main_player (the PlayerIns*).
+//   Resolved raw HP address =
+//     *(*(*(*(WorldChrMan_base + 0x10EF8) + 0x0) + 0x190) + 0x0) + 0x138
+//   i.e. from the main_player PlayerIns:  +0x0 (PlayerIns/ChrIns base) -> +0x190 (module bag's
+//   data-module ptr) -> +0x138 (current HP, 4-byte int). MaxHP is the adjacent +0x13C cell
+//   (CE "MaxHP" ct lines 4977-4988), which is exactly CSChrDataModule.max_hp here.
+//
+// Typed reconciliation (docs.rs, eldenring 0.14):
+//   * ChrIns.modules : OwnedPtr<ChrInsModuleContainer>   (the +0x190 "module bag" hop)
+//   * ChrInsModuleContainer.data : OwnedPtr<CSChrDataModule>  (the data-module ptr)
+//   * CSChrDataModule { .. chara_init_param_id: i32, hp: i32, max_hp: i32, .. }
+//       -> `hp` is current HP (the +0x138 cell), `max_hp` the +0x13C cell.
+//   PlayerIns derefs to ChrIns (flags.rs reads `play_region_id`, a ChrIns field, straight off
+//   `main_player`), so `main_player.as_ref()?.modules.data.hp` is the full chain. Using the typed
+//   fields keeps this robust across patches that shift the numeric offsets.
+//
+// `with_player_hp` resolves &mut CSChrDataModule from the in-world main_player, verifying each hop
+// is present, and hands it to a closure. Returns None (no-op) if anything is null / not in-world, so
+// a wrong/late chain can NEVER turn into a bad write — callers treat None as "couldn't act, retry".
+fn with_player_hp<R>(f: impl FnOnce(&mut CSChrDataModule) -> R) -> Option<R> {
+    // Defensive in-world re-check (callers already gate, but a stray call must stay safe).
+    if !flags::in_world() {
+        return None;
+    }
+    // Resolve the singleton MUTABLY (we may write hp); instance_mut is the same FromStatic accessor
+    // flags.rs uses for CSEventFlagMan::instance_mut. Bail (no-op) before it inits or if absent.
+    let wcm = unsafe { WorldChrMan::instance_mut() }.ok()?;
+    // main_player is a nullable pointer (flags.rs uses as_ref()? on it); a mutable borrow lets the
+    // read (read_local_death) and write (kill_player) share one resolver. None => not placed yet.
+    let player = wcm.main_player.as_mut()?;
+    // ChrIns.modules -> ChrInsModuleContainer (OwnedPtr derefs to the container).
+    // CSChrDataModule lives behind ChrInsModuleContainer.data (the +0x190 data module).
+    let data: &mut CSChrDataModule = &mut player.modules.data;
+    Some(f(data))
+}
+
+/// Dedicated "DeathLink death" event flag. The client SETS it; a baked `common.emevd` event
+/// (`patch_baker_deathlink_kill.py`) reacts with `ForceCharacterDeath(player, ShouldReceiveRunes=TRUE)`
+/// then clears it. A NEW flag (not the region-kick's 76970) so the kill works with OR without region
+/// locks, never warps, and doesn't collide with the client's KICK latch (features.rs also sets 76970).
+/// In the valid grace-tail flag group (kick 76970, region locks 76971-76995, DLC entry 76999);
+/// 76996 is a free slot in that group (NOT a region-lock flag — those are 76971-76995).
+const DEATHLINK_KILL_FLAG: u32 = 76996;
+
+/// Kill the local player on an INCOMING DeathLink. Returns `true` once the request is handed off
+/// (latch clears), `false` while it can't be applied yet (latch kept, retried next in-world tick).
+///
+/// **Approach: SET the baked DeathLink-death flag**, letting the EMEVD do the actual kill via
+/// `ForceCharacterDeath` — the SAME game-native death the region-lock KICK uses (er-kick-kill-keep-runes).
+/// This is strictly better than a raw `hp = 0` write: (a) it can't be HP-clamped/recomputed, and
+/// (b) the EMEVD passes **Should Receive Runes = TRUE**, so a DeathLink death KEEPS YOUR RUNES (a
+/// raw hp=0 would drop a bloodstain and lose them). The kill itself lives in the baker
+/// (`patch_baker_deathlink_kill.py`); the client's whole job is to set the flag, which it does
+/// reliably. Returns false until CSEventFlagMan is up (caller keeps the latch and retries).
+fn kill_player() -> bool {
+    flags::try_set_event_flag(DEATHLINK_KILL_FLAG, true)
+}
+
+// =================================================================================================
+// OUTGOING — game tick detects local death, net thread sends.
+// =================================================================================================
+
+/// Game thread (called from `tick`): detect that the LOCAL player JUST died (rising edge) and latch
+/// an outgoing DeathLink for the net thread. Edge-detected against `WAS_DEAD` so one death yields one
+/// Bounce, not one per frame the death screen is up. Suppressed while a kill we just RECEIVED is
+/// being applied? No — DeathLink intentionally does NOT re-broadcast deaths it caused, but that's
+/// handled at the RECEIVER (self-source guard) and by the death-cause check, so we keep this simple:
+/// any local death edge sends. (If echo-storms appear in playtest, gate this on
+/// `!KILL_PENDING && !<just-applied-incoming>` here.)
+pub fn poll_outgoing_death() {
+    if !flags::in_world() {
+        // Off-world (menu/load): clear the edge state so re-entering the world after a respawn
+        // doesn't read as a fresh death. Don't send.
+        WAS_DEAD.store(false, Ordering::Relaxed);
+        return;
+    }
+    let dead_now = read_local_death();
+    let was_dead = WAS_DEAD.swap(dead_now, Ordering::Relaxed);
+    if dead_now && !was_dead {
+        tracing::info!("AP: local death detected — queueing outgoing DeathLink");
+        SEND_PENDING.store(true, Ordering::Release);
+    }
+}
+
+/// Net thread (called each loop iteration in net.rs): take + clear the outgoing-death latch. Returns
+/// true exactly once per detected local death; net.rs then calls `client.death_link(..)`.
+pub fn take_pending_outgoing() -> bool {
+    SEND_PENDING.swap(false, Ordering::Acquire)
+}
+
+/// ⚠️ `// RE:` HOLE #2 — read whether the local player is currently DEAD. Returns `true` on the
+/// death frame(s); `poll_outgoing_death`'s `WAS_DEAD` rising-edge latch turns a sustained `true`
+/// into exactly one outgoing DeathLink and absorbs the 1-frame respawn window where HP can read 0
+/// before the bonfire heal.
+///
+/// **Approach A: current HP == 0.** Reuse the SAME `CSChrDataModule.hp` cell `kill_player` writes
+/// (CE "HP", +0x138). Read-only: resolve the chain through `with_player_hp` and report `hp <= 0`.
+/// If any hop is null / not in-world we return `false` (treated as "alive / unknown" — we simply
+/// don't originate a DeathLink), which is the safe default.
+fn read_local_death() -> bool {
+    // RE: read WorldChrMan.main_player -> ChrIns.modules.data.hp; dead == (hp <= 0). Read-only.
+    with_player_hp(|data| data.hp <= 0).unwrap_or(false)
+}

--- a/crates/eldenring-archipelago/src/game/deathlink.rs
+++ b/crates/eldenring-archipelago/src/game/deathlink.rs
@@ -144,7 +144,7 @@ fn drive_incoming_kill() {
     } else {
         // kill_player is still a RE stub: log ONCE per latch so we don't spam every frame while the
         // hole is open. The latch stays set; once the RE lands it'll succeed and clear.
-        if KILL_LOGGED.swap(true, Ordering::Relaxed) == false {
+        if !KILL_LOGGED.swap(true, Ordering::Relaxed) {
             tracing::warn!(
                 "AP: DeathLink kill requested but kill_player() is an unfilled RE stub — \
                  player NOT killed (see deathlink.rs kill_player worksheet)"

--- a/crates/eldenring-archipelago/src/game/detour.rs
+++ b/crates/eldenring-archipelago/src/game/detour.rs
@@ -1,0 +1,222 @@
+//! DETECT + GRANT layer — the `AddItemFunc` detour (Phase 3). Replaces the MinHook detour in the
+//! C++ `er_gamehook_win.cpp` with retour's STABLE `GenericDetour` (the nightly `static_detour!` is
+//! gone — fromsoftware-rs pins stable; see the spike root's VERIFY-RESOLUTION.md).
+//!
+//! `AddItemFunc` is the linchpin: every item lot routes through it, so hooking its entry yields
+//! pickup DETECTION, and calling the trampoline (`HOOK.call(...)`) performs the original GRANT.
+//! Binding facts (build-pinned, CE-cross-validated) come from the C++ `er_hooks.h`.
+//!
+//! STILL OPEN (real RE, not symbol lookup): a version-robust AOB scan for AddItemFunc — today it's
+//! module base + the pinned 2.6.2.0 RVA, guarded by a leading-byte signature so a WRONG address
+//! REFUSES to install instead of detouring garbage and crashing. Local grant (Phase 3b): SUPPRESS
+//! the world pickup (return 0 -> no full "You got" acquisition popup) and grant the item via a
+//! STANDALONE AddItemFunc call with a constructed descriptor (C++ GrantItem port) so it uses ER's
+//! non-interrupting item-gain TICKER. Reuses the live inventory pointer the detour is handed.
+
+use std::ffi::c_void;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::OnceLock;
+
+use retour::GenericDetour;
+
+use er_codec::{decide_pickup, decode_synthetic, is_synthetic_goods, row_id_of, PickupAction};
+
+use super::{flags, params};
+
+/// Raw target ABI: AddItemFunc(rcx = inventory, rdx = &itembuf entry, r8 = &itembuf, r9 = 0).
+type AddItemFn = unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, u64) -> u64;
+
+/// The installed detour. `GenericDetour<T>` is `Send + Sync` (docs.rs/retour 0.3.1), so a `static`
+/// `OnceLock` is its home; we keep it for the process lifetime and call `.call(..)` on it to reach
+/// the original function from inside the hook.
+static HOOK: OnceLock<GenericDetour<AddItemFn>> = OnceLock::new();
+
+/// Live inventory instance pointer (rcx) captured from the most recent AddItemFunc detour call.
+/// Phase 4 reuses it to grant SERVER-pushed items (which never trigger a pickup) without a
+/// separate InventoryAccessor AOB scan — the detour already holds the pointer the game uses.
+static LAST_INVENTORY: AtomicUsize = AtomicUsize::new(0);
+
+// --- AddItemFunc binding (er_hooks.h, eldenring.exe 2.6.2.0) --------------------------------------
+const ADD_ITEM_FUNC_RVA: usize = 0x0056_05B0;
+// Leading concrete bytes of the prologue (wildcard tail dropped) — the install guard.
+const ADD_ITEM_FUNC_SIG: &[u8] = &[
+    0x40, 0x55, 0x56, 0x57, 0x41, 0x54, 0x41, 0x55, 0x41, 0x56, 0x41, 0x57, 0x48, 0x8D, 0xAC, 0x24,
+];
+
+// itembuffer entry layout: rdx points at the entry (itembuf + 0x20); id at entry+0x04.
+const ITEMBUF_ENTRY_ID_OFF: usize = 0x04; // s32: itemId | (categoryNibble << 28), at entry+0x04
+const ITEMBUF_ENTRY_OFF: usize = 0x20; // a constructed itembuf's entry sits at buf+0x20 (C++ GrantItem)
+
+/// Resolve `AddItemFunc`, verify its signature, and install the detour. Idempotent.
+pub fn install() -> Result<(), Box<dyn std::error::Error>> {
+    if HOOK.get().is_some() {
+        return Ok(());
+    }
+    let target_addr =
+        resolve_add_item_func().ok_or("AddItemFunc address unresolved (no module base)")?;
+
+    // Guard: refuse a wrong address (stale RVA for this game build) — detouring the wrong bytes
+    // would crash. SAFETY: target_addr is inside the loaded module's mapped .text.
+    if !signature_matches(target_addr) {
+        super::breadcrumb("detour: SIGNATURE MISMATCH at AddItemFunc RVA; NOT installing");
+        return Err(format!(
+            "AddItemFunc signature mismatch @ {target_addr:#x} — pinned RVA is stale for this game build (needs an AOB scan / matching version)"
+        )
+        .into());
+    }
+
+    // SAFETY: target_addr points at the resolved AddItemFunc; the detour fn matches its ABI.
+    let target: AddItemFn = unsafe { std::mem::transmute::<usize, AddItemFn>(target_addr) };
+    let detour = unsafe { GenericDetour::<AddItemFn>::new(target, add_item_detour)? };
+    unsafe {
+        detour.enable()?;
+    }
+    let _ = HOOK.set(detour);
+    super::breadcrumb("detour: AddItemFunc hook installed + enabled");
+    tracing::info!("AddItemFunc detour installed @ {target_addr:#x}");
+    Ok(())
+}
+
+/// Call the original AddItemFunc via the trampoline (bypasses the hook). Returns 0 if the hook
+/// somehow isn't set — never re-enters the detour.
+fn call_original(inventory: *mut c_void, entry: *mut c_void, itembuf: *mut c_void, r9: u64) -> u64 {
+    match HOOK.get() {
+        // SAFETY: calls the original AddItemFunc via retour's trampoline with the exact ABI.
+        Some(h) => unsafe { h.call(inventory, entry, itembuf, r9) },
+        None => 0,
+    }
+}
+
+/// The detour body. Tiny unsafe surface: read the inbound id, hand the *decision* to pure `er_codec`,
+/// and either suppress (drop placeholder + report the check) or pass through to the real function.
+unsafe extern "C" fn add_item_detour(
+    inventory: *mut c_void,
+    entry: *mut c_void,
+    itembuf: *mut c_void,
+    r9: u64,
+) -> u64 {
+    // Phase 4: cache the live inventory pointer on EVERY pickup (vanilla or synthetic) so the
+    // server-pushed grant path has a valid inventory instance soon after the first pickup.
+    LAST_INVENTORY.store(inventory as usize, Ordering::Relaxed);
+
+    // SAFETY: `entry` is the descriptor the game passes (rdx); id at entry+0x04.
+    let raw_id = read_i32(entry, ITEMBUF_ENTRY_ID_OFF) as u32;
+
+    if !is_synthetic_goods(raw_id) {
+        return call_original(inventory, entry, itembuf, r9);
+    }
+
+    match params::goods_row_fields(row_id_of(raw_id) as i32) {
+        Some(fields) => {
+            let item = decode_synthetic(&fields);
+            tracing::info!(
+                "AP check: synthetic goods {raw_id:#x} -> location {} (local item {} x{}, foreign={})",
+                item.ap_location_id,
+                item.local_item_id,
+                item.local_quantity,
+                item.foreign_remove
+            );
+            // REPORT: every synthetic pickup is an AP check, local or foreign.
+            flags::report_location(item.ap_location_id);
+
+            // SUPPRESS the world pickup (return 0 -> no "You got" popup) and rely on the SERVER ECHO
+            // for the grant: items_handling 0b111 (own_world=true, net.rs) re-sends every own-world
+            // item when its location is checked, and that single echoed copy is granted by
+            // `grant_full_id` off the received-item stream (deduped by last_received_index). Granting
+            // LOCALLY here as well (the Phase-3 `SuppressAndGrant`) double-granted every self-found
+            // item once the echo path went live in Phase 4/5. Echo-only is also why shop-buys work:
+            // they bypass this detour, get reported via flag-polling, and grant through the same echo.
+            // (Matches the C++ client, which suppresses + reports and never grants locally.)
+            match decide_pickup(&item) {
+                PickupAction::SuppressAndGrant | PickupAction::Suppress => 0,
+            }
+        }
+        None => {
+            tracing::warn!("synthetic id {raw_id:#x} but goods row unresolved; passing through");
+            call_original(inventory, entry, itembuf, r9)
+        }
+    }
+}
+
+/// Phase 4: grant a SERVER-pushed item by constructing a fresh itembuf and calling the original
+/// AddItemFunc through the trampoline. Local self-found pickups are granted by the in-place
+/// descriptor rewrite in the detour; server/foreign items never pass through a pickup, so we
+/// build the 0x50-byte buffer the game expects (port of er_gamehook GrantItem) and reuse the
+/// inventory pointer captured by the detour. Returns false if the hook isn't installed or no
+/// inventory pointer has been captured yet (no pickup this session) — caller keeps the item
+/// queued. MUST run on the game thread (the FrameBegin tick).
+pub fn grant_full_id(full_id: i32, qty: i32) -> bool {
+    if HOOK.get().is_none() {
+        return false;
+    }
+    // auto_upgrade (Phase 5, RE-gated): every AP-received item — local self-found (echo), foreign,
+    // notify, start — funnels through here, so this is the single choke point to raise a granted
+    // weapon to the player's current max reinforce level. INERT until the RE holes in upgrades.rs are
+    // filled (returns full_id unchanged); non-weapons pass through. `net`-only (lean detour build has
+    // no upgrades module). Mirrors the C++ GrantItem AutoUpgradeWeaponId site.
+    #[cfg(feature = "net")]
+    let full_id = super::upgrades::apply_auto_upgrade(full_id);
+    let inv = LAST_INVENTORY.load(Ordering::Relaxed);
+    if inv < 0x10000 {
+        return false; // no inventory instance captured yet; retry after the next pickup
+    }
+    // Reuse the existing constructed-descriptor grant (port of the C++ GrantItem) with the live
+    // inventory pointer the detour captured. goods->goods; full_id already carries the category nibble.
+    grant_item(inv as *mut c_void, full_id, qty);
+    true
+}
+
+/// Resolve the function address. TODO (version-robustness): replace the pinned RVA with an AOB scan
+/// of the module .text. Today: module base + pinned 2.6.2.0 RVA, guarded by signature_matches().
+fn resolve_add_item_func() -> Option<usize> {
+    Some(current_module_base()? + ADD_ITEM_FUNC_RVA)
+}
+
+/// Base address of the host process module (`eldenring.exe`). `GetModuleHandleW(None)` -> HMODULE;
+/// `HMODULE(pub *mut c_void)`, so the base as `usize` is `hmodule.0 as usize`.
+fn current_module_base() -> Option<usize> {
+    use windows::Win32::System::LibraryLoader::GetModuleHandleW;
+    let hmodule = unsafe { GetModuleHandleW(None) }.ok()?;
+    Some(hmodule.0 as usize)
+}
+
+/// True iff the bytes at `addr` start with the AddItemFunc prologue signature.
+/// SAFETY: reads ADD_ITEM_FUNC_SIG.len() bytes from `addr`; caller passes a module .text address.
+fn signature_matches(addr: usize) -> bool {
+    let actual = unsafe { std::slice::from_raw_parts(addr as *const u8, ADD_ITEM_FUNC_SIG.len()) };
+    actual == ADD_ITEM_FUNC_SIG
+}
+
+/// SAFETY: caller guarantees `base + off + 4` is readable.
+unsafe fn read_i32(base: *const c_void, off: usize) -> i32 {
+    let p = (base as *const u8).add(off) as *const i32;
+    p.read_unaligned()
+}
+
+/// Grant an item via a STANDALONE AddItemFunc call with a constructed descriptor (port of the C++
+/// `GrantItem`). Reuses the live `inventory` pointer the detour was handed. Because this is a direct
+/// call (not the world-pickup flow), the game shows its non-interrupting item-gain TICKER rather
+/// than the full "You got" acquisition popup. `id_with_category` already carries the category nibble.
+fn grant_item(inventory: *mut c_void, id_with_category: i32, quantity: i32) {
+    if id_with_category == 0 || inventory.is_null() {
+        return;
+    }
+    // 0x50-byte descriptor, 8-aligned (C++ alignas(8); CE table): entry count @+0x20=1, id @+0x24,
+    // qty @+0x28, gem @+0x30=-1, trailing -1s @ +0x34 / +0x40(i64) / +0x4C. entry = buf+0x20.
+    let mut buf = [0u64; 0x50 / 8];
+    let base = buf.as_mut_ptr() as *mut u8;
+    unsafe {
+        (base.add(0x20) as *mut i32).write_unaligned(1);
+        (base.add(0x24) as *mut i32).write_unaligned(id_with_category);
+        (base.add(0x28) as *mut i32).write_unaligned(quantity);
+        (base.add(0x30) as *mut i32).write_unaligned(-1);
+        (base.add(0x34) as *mut i32).write_unaligned(-1);
+        (base.add(0x40) as *mut i64).write_unaligned(-1);
+        (base.add(0x4C) as *mut i32).write_unaligned(-1);
+        let entry = base.add(ITEMBUF_ENTRY_OFF) as *mut c_void;
+        let itembuf = base as *mut c_void;
+        if let Some(h) = HOOK.get() {
+            h.call(inventory, entry, itembuf, 0);
+        }
+    }
+}

--- a/crates/eldenring-archipelago/src/game/features.rs
+++ b/crates/eldenring-archipelago/src/game/features.rs
@@ -1,0 +1,649 @@
+//! Phase 5 — ER feature surface ported onto the Phase-4 net/grant plumbing.
+//!
+//! Almost every C++ feature is the same three-step pattern (PHASE5-PORT-PLAN.md):
+//!   1. RECEIVE (net thread, keyed by item NAME): look the AP item name up in a table and QUEUE an
+//!      effect (a grace/open/reveal event flag, or a one-off item grant).
+//!   2. TICK (game thread): drain those queues with `flags::set_event_flag` / `detour::grant_full_id`,
+//!      and poll game state (`play_region_id`, event flags) for warp latches / location sweeps.
+//!   3. PERSIST: a couple of features extend the Phase-4 save (`start_items_granted`, `notify_granted`).
+//!
+//! Thread rule (inherited from Phase 4): NAME-keyed decisions run on the NET thread and only QUEUE;
+//! every event-flag write / grant / flag read happens on the FrameBegin TICK. Never touch game memory
+//! from the net thread.
+//!
+//! This module is the Rust port of: `CCore::FlushPendingGraceFlags`, the `pendingNotifyGrants` /
+//! `pendingStartItems` drains, `CCore::PollLocationFlags`, `CCore::EvaluateNaturalKeyTriggers`, the
+//! warp-latch / region-lock-KICK block in `CCore::Run`, `CGameHook::revealAllMaps`, and the
+//! `set_items_received_handler` name-dispatch in `ArchipelagoInterface.cpp`.
+
+#![allow(dead_code)] // handlers are wired ahead of every caller while Phase 5 lands
+
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
+use std::sync::{Mutex, OnceLock};
+
+use super::{detour, flags, grant};
+
+// =================================================================================================
+// Slot config (parsed once at connect on the net thread; read every tick on the game thread).
+// =================================================================================================
+
+/// A natural-key trigger clause: satisfied when ALL `items` were received (by name) AND ALL `flags`
+/// are set. ANY clause for a region blooms it. (`Core::NKClause`.)
+#[derive(Clone, Default)]
+pub struct NkClause {
+    pub items: Vec<String>,
+    pub flags: Vec<u32>,
+}
+
+/// Everything the server (slot_data) and apconfig tell the client to do, beyond the goods-only MVP.
+/// Built by `net.rs` at connect, handed to `configure()`. All fields default-empty so an older seed
+/// that omits a key is simply inert (never wrong).
+#[derive(Default)]
+pub struct SlotConfig {
+    // --- name-keyed region-lock ecosystem (item NAME -> effect) ---
+    pub region_graces: HashMap<String, Vec<u32>>, // lock item -> grace warp-unlock flags
+    pub grace_items: HashMap<String, u32>,        // grace item -> one warp flag
+    pub region_open_flags: HashMap<String, u32>,  // lock item -> one physical region-open flag
+    pub lock_reveal_flags: HashMap<String, Vec<u32>>, // lock item -> map-reveal/open flags
+    pub lock_notify_items: HashMap<String, i32>,  // lock item -> FullID granted as the unlock notice
+    pub natural_key_triggers: HashMap<String, Vec<NkClause>>, // region -> clause disjunction
+
+    // --- warp latches (game-state -> set a baked warp flag once) ---
+    pub dlc_entry_warp_flag: u32,
+    pub dlc_start_area_id: i32,
+    pub random_start_warp_flag: u32,
+    pub random_start_area_id: i32,
+    pub random_start_done_flag: u32,
+
+    // --- region-lock physical enforcement (KICK) ---
+    pub area_lock_flags: Vec<[i32; 3]>, // [lo, hi, open_flag] inclusive subregion ranges
+
+    // --- map reveal (map_option=give: no map items granted) ---
+    pub reveal_all_maps: bool,
+    pub enable_dlc: bool,
+
+    // --- check polling (acquisitions that bypass the AddItemFunc detour) ---
+    pub location_flags: HashMap<i64, u32>,  // apconfig: AP location id -> guarding event flag
+    pub sweep_flags: HashMap<u32, Vec<i64>>, // apconfig: event flag -> AP location ids
+    pub dungeon_sweeps: HashMap<i64, Vec<i64>>, // slot_data: trigger location -> member locations
+}
+
+fn config() -> &'static Mutex<SlotConfig> {
+    static C: OnceLock<Mutex<SlotConfig>> = OnceLock::new();
+    C.get_or_init(|| Mutex::new(SlotConfig::default()))
+}
+
+// =================================================================================================
+// Cross-thread queues + per-session sets (Step 0 plumbing).
+// =================================================================================================
+
+/// Event flags queued (net thread) for the tick to SET via FlushPendingGraceFlags. Grace warp
+/// flags, region-open flags, map-reveal flags, companion/key-item obtained flags, natural-key blooms.
+fn pending_grace_flags() -> &'static Mutex<VecDeque<u32>> {
+    static Q: OnceLock<Mutex<VecDeque<u32>>> = OnceLock::new();
+    Q.get_or_init(|| Mutex::new(VecDeque::new()))
+}
+
+/// FullIDs queued (net thread) for the tick to GRANT once-per-save as an unlock notice / great-rune
+/// restore (`pendingNotifyGrants`). Granted via `grant::notify_already_granted` dedup.
+fn pending_notify_grants() -> &'static Mutex<VecDeque<i32>> {
+    static Q: OnceLock<Mutex<VecDeque<i32>>> = OnceLock::new();
+    Q.get_or_init(|| Mutex::new(VecDeque::new()))
+}
+
+/// (FullID, count) start items queued at connect (Torrent, flasks, quick_start runes), granted
+/// EXACTLY ONCE per save (`pendingStartItems`).
+fn pending_start_items() -> &'static Mutex<VecDeque<(i32, i32)>> {
+    static Q: OnceLock<Mutex<VecDeque<(i32, i32)>>> = OnceLock::new();
+    Q.get_or_init(|| Mutex::new(VecDeque::new()))
+}
+
+/// AP item NAMES received this session (rebuilt from the items_received replay on reconnect, so no
+/// persistence). Drives natural-key trigger evaluation. (`Core->receivedItemNames`.)
+fn received_names() -> &'static Mutex<HashSet<String>> {
+    static S: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+    S.get_or_init(|| Mutex::new(HashSet::new()))
+}
+
+/// Grace flags already set THIS session — suppresses redundant SetEventFlag + log noise.
+fn grace_set_this_session() -> &'static Mutex<HashSet<u32>> {
+    static S: OnceLock<Mutex<HashSet<u32>>> = OnceLock::new();
+    S.get_or_init(|| Mutex::new(HashSet::new()))
+}
+
+/// AP locations already reported by flag polling — dedup across ticks/sessions.
+fn flag_sent_locations() -> &'static Mutex<HashSet<i64>> {
+    static S: OnceLock<Mutex<HashSet<i64>>> = OnceLock::new();
+    S.get_or_init(|| Mutex::new(HashSet::new()))
+}
+
+/// reveal_all_maps one-shot, re-armed each connect (`revealAllMapsPending`).
+static REVEAL_MAPS_PENDING: AtomicBool = AtomicBool::new(false);
+
+// =================================================================================================
+// Const tables (client-owned, NOT slot_data). Ported verbatim from ArchipelagoInterface.cpp /
+// GameHook.cpp so the same vanilla flags / restored rows fire as the C++ client.
+// =================================================================================================
+
+/// Companion items whose possession is gated by a vanilla "obtained" EVENT FLAG a raw goods-grant
+/// never trips (summon tutorial, Twin Maiden dup-sale stop, whetblade affinities).
+const COMPANION_ACQUIRE_FLAGS: &[(&str, &[u32])] = &[
+    ("Spirit Calling Bell", &[60110]),
+    ("Whetstone Knife", &[60130]),
+    ("Iron Whetblade", &[65610]),
+    ("Red-Hot Whetblade", &[65640]),
+    ("Sanctified Whetblade", &[65660]),
+    ("Glintstone Whetblade", &[65680]),
+    ("Black Whetblade", &[65720]),
+];
+
+/// Vanilla KEY ITEMS whose progression gate reads an obtained EVENT FLAG, not inventory.
+const KEY_ITEM_ACQUIRE_FLAGS: &[(&str, &[u32])] = &[
+    ("Rold Medallion", &[400001]),   // Grand Lift of Rold
+    ("Drawing-Room Key", &[400072]), // Volcano Manor drawing-room transition
+];
+
+/// Great runes arrive UNRESTORED under num_regions_rune_source=pool; granting the matching ER
+/// "(Restored)" EquipParamGoods row (191-196) is the same state the Divine Tower confers, so the
+/// player can equip + Rune-Arc immediately. Granted ADDITIVELY (the raw rune still grants too).
+const GREAT_RUNE_RESTORE_GOODS: &[(&str, u32)] = &[
+    ("Godrick's Great Rune", 191),
+    ("Radahn's Great Rune", 192),
+    ("Morgott's Great Rune", 193),
+    ("Rykard's Great Rune", 194),
+    ("Mohg's Great Rune", 195),
+    ("Malenia's Great Rune", 196),
+];
+
+/// GOODS category nibble (a FullID is `id | (category << 28)`; goods = 0x4). Restored great runes +
+/// map fragments are granted as goods-packed FullIDs, identical to the C++ `| 0x40000000`.
+const GOODS_FULLID: i32 = 0x4000_0000u32 as i32;
+
+/// Map fragment goods id -> its map-REVEAL event flag. The goods item only fills inventory; the
+/// region map stays fogged until this separate flag is set (vanilla pickup events set both).
+/// Base ids < 2_000_000; DLC (Land of Shadow) pieces are the `2008600..` block (skipped when DLC off).
+const MAP_UNLOCK_FLAGS: &[(i32, u32)] = &[
+    (8600, 62010), (8601, 62011), (8602, 62012), // Limgrave W, Weeping, Limgrave E
+    (8603, 62020), (8604, 62021), (8605, 62022), // Liurnia E/N/W
+    (8606, 62030), (8607, 62031), (8608, 62032), // Altus, Leyndell, Gelmir
+    (8609, 62040), (8610, 62041),                // Caelid, Dragonbarrow
+    (8611, 62050), (8612, 62051), (8618, 62052), // Mountaintops W/E, Snowfield
+    (8613, 62060), (8614, 62061), (8616, 62062), // Ainsel, Lake of Rot, Mohgwyn
+    (8615, 62063), (8617, 62064),                // Siofra, Deeproot
+    (2008600, 62080), // Gravesite Plain  (WorldMapPieceParam 1000)
+    (2008601, 62081), // Scadu Altus      (1001)
+    (2008602, 62082), // Southern Shore   (1002)
+    (2008603, 62083), // Rauh Ruins       (1003)
+    (2008604, 62084), // Abyss            (1004)
+    (2008605, 82001), // + DLC map page-unlock (synthetic key carries 82001)
+];
+
+/// KICK event flag (76970): set when the player is inside a locked region whose open-flag is off; the
+/// baked common.emevd reactor warps them out to a safe Limgrave grace.
+const KICK_FLAG: u32 = 76970;
+/// "DLC entered" flag (62002) — guards the DLC auto-entry latch so it fires once, not on a revisit.
+const DLC_ENTERED_FLAG: u32 = 62002;
+
+// =================================================================================================
+// NET THREAD — config install + name-keyed receive dispatch.
+// =================================================================================================
+
+/// Net thread, at (re)connect: install the parsed slot/apconfig tables and RESET per-session state
+/// (so a fresh connect re-blooms / re-polls cleanly; persisted dedup lives in `grant`).
+pub fn configure(cfg: SlotConfig) {
+    REVEAL_MAPS_PENDING.store(cfg.reveal_all_maps, Ordering::Relaxed);
+    *config().lock().unwrap() = cfg;
+    received_names().lock().unwrap().clear();
+    grace_set_this_session().lock().unwrap().clear();
+    flag_sent_locations().lock().unwrap().clear();
+    pending_grace_flags().lock().unwrap().clear();
+    pending_notify_grants().lock().unwrap().clear();
+    pending_start_items().lock().unwrap().clear();
+    queue_start_items();
+    queue_start_graces();
+}
+
+/// Net thread: queue the Limgrave start graces parsed at connect (drained like the on-receipt bundle).
+fn queue_start_graces() {
+    // start graces live in region_graces under the reserved key "" (see net.rs parse); plus any
+    // dedicated startGraces vector is folded into the same queue there. Nothing to do here unless
+    // we later separate them — kept as a hook so the call site reads symmetrically with start items.
+}
+
+/// Net thread: move the parsed start items onto the once-per-save queue. Called from `configure`.
+fn queue_start_items() {
+    // start items are parsed straight into the queue by net.rs via `enqueue_start_item`, so this is
+    // a no-op hook kept for symmetry with `queue_start_graces`.
+}
+
+/// Net thread: parse-time helper so net.rs can push a Limgrave start grace flag.
+pub fn enqueue_start_grace(flag: u32) {
+    pending_grace_flags().lock().unwrap().push_back(flag);
+}
+
+/// Net thread: parse-time helper so net.rs can push a once-per-save start item (FullID, count).
+pub fn enqueue_start_item(full_id: i32, count: i32) {
+    pending_start_items().lock().unwrap().push_back((full_id, count.max(1)));
+}
+
+/// Net thread: dispatch ONE received item by NAME (idempotent — safe to call for the full replay on
+/// every reconnect). Pushes effects onto the grace / notify queues; the game tick applies them.
+///
+/// Mirrors `set_items_received_handler`. NOTE: the caller dispatches over ALL received items (not
+/// just those past the grant watermark) so the received-NAME set + idempotent flags rebuild on
+/// reconnect — the GRANT path is what's deduped by `last_received_index`, not this.
+pub fn on_item_received(name: &str) {
+    received_names().lock().unwrap().insert(name.to_string());
+
+    let cfg = config().lock().unwrap();
+    let mut graces = pending_grace_flags().lock().unwrap();
+    let mut notify = pending_notify_grants().lock().unwrap();
+
+    // Region-fusion grace bundle: lock item -> grace warp-unlock flags.
+    if let Some(fs) = cfg.region_graces.get(name) {
+        for &f in fs {
+            graces.push_back(f);
+        }
+        tracing::info!("Region lock '{}' received: queued {} grace flag(s)", name, fs.len());
+    }
+    // Grace rando: grace item -> one warp flag.
+    if let Some(&f) = cfg.grace_items.get(name) {
+        graces.push_back(f);
+        tracing::info!("Grace item '{}' received: queued warp flag {}", name, f);
+    }
+    // Region-open (physical fog gate): lock item -> one open flag.
+    if let Some(&f) = cfg.region_open_flags.get(name) {
+        graces.push_back(f);
+        tracing::info!("Region lock '{}' received: queued region-open flag {}", name, f);
+    }
+    // Generalized reveal/open: lock item -> map-reveal + enforcement-open flags.
+    if let Some(fs) = cfg.lock_reveal_flags.get(name) {
+        for &f in fs {
+            graces.push_back(f);
+        }
+        tracing::info!("Region lock '{}' received: queued {} reveal/open flag(s)", name, fs.len());
+    }
+    // Unlock notification item (map fragment / token) -> once-per-save grant queue.
+    if let Some(&addr) = cfg.lock_notify_items.get(name) {
+        notify.push_back(addr);
+    }
+
+    // Companion acquisition flags.
+    if let Some(fs) = lookup(COMPANION_ACQUIRE_FLAGS, name) {
+        for &f in fs {
+            graces.push_back(f);
+        }
+        tracing::info!("Companion item '{}' received: queued {} acquisition flag(s)", name, fs.len());
+    }
+    // Key-item acquisition flags.
+    if let Some(fs) = lookup(KEY_ITEM_ACQUIRE_FLAGS, name) {
+        for &f in fs {
+            graces.push_back(f);
+        }
+        tracing::info!("Key item '{}' received: queued {} obtained-flag(s)", name, fs.len());
+    }
+    // Great-rune restore: ADDITIONALLY grant the "(Restored)" goods row (once per save via notify).
+    if let Some(goods) = GREAT_RUNE_RESTORE_GOODS.iter().find(|(n, _)| *n == name).map(|(_, g)| *g) {
+        notify.push_back((goods as i32) | GOODS_FULLID);
+        tracing::info!("Great rune '{}' received: also granting restored goods {} (usable now)", name, goods);
+    }
+}
+
+fn lookup(table: &'static [(&'static str, &'static [u32])], name: &str) -> Option<&'static [u32]> {
+    table.iter().find(|(n, _)| *n == name).map(|(_, f)| *f)
+}
+
+// =================================================================================================
+// GAME THREAD — the settled-in-world tick. Every event-flag read/write + grant happens here.
+// =================================================================================================
+
+/// Game-thread tick (called from `game::tick`). No-op until the player is settled in-world; then it
+/// drains the grace/notify/start queues, reveals maps, evaluates natural keys, polls location flags,
+/// and runs the warp / region-lock latches. Mirrors the in-world poll block of `CCore::Run`.
+pub fn tick() {
+    if !settled_in_world() {
+        return;
+    }
+    drain_notify_grants();
+    drain_start_items();
+    reveal_maps_if_pending();
+    flush_grace_flags();
+    evaluate_natural_key_triggers();
+    poll_location_flags();
+    warp_and_lock_latches();
+}
+
+/// Require a real `play_region_id` for a couple of consecutive ticks before granting/setting flags —
+/// the C++ `s_inWorldStableTicks >= 2` crash-fix: `InventoryInstance()!=0` goes true DURING load-in,
+/// before the player is placed, and AddItem faults then.
+fn settled_in_world() -> bool {
+    const SETTLE_TICKS: i32 = 2;
+    static STABLE: AtomicI32 = AtomicI32::new(0);
+    if flags::in_world() {
+        let n = STABLE.load(Ordering::Relaxed);
+        if n < SETTLE_TICKS {
+            STABLE.store(n + 1, Ordering::Relaxed); // saturate; never overflows on a long session
+        }
+        STABLE.load(Ordering::Relaxed) >= SETTLE_TICKS
+    } else {
+        STABLE.store(0, Ordering::Relaxed);
+        false
+    }
+}
+
+/// Grant queued unlock-notify items (map fragment / token) + great-rune restores, EXACTLY ONCE per
+/// save. `grant::notify_already_granted` is the persisted dedup; the lock EFFECTS run separately via
+/// idempotent flags, so a skipped replay needs no re-application. (`pendingNotifyGrants` drain.)
+fn drain_notify_grants() {
+    let mut q = pending_notify_grants().lock().unwrap();
+    if q.is_empty() {
+        return;
+    }
+    let mut granted = 0;
+    let mut requeue: VecDeque<i32> = VecDeque::new();
+    while let Some(addr) = q.pop_front() {
+        if grant::notify_already_granted(addr) {
+            continue;
+        }
+        if !detour::grant_full_id(addr, 1) {
+            requeue.push_back(addr); // no inventory pointer captured yet; retry next tick
+            continue;
+        }
+        grant::note_notify_granted(addr);
+        granted += 1;
+    }
+    *q = requeue;
+    drop(q);
+    if granted > 0 {
+        tracing::info!("Region-lock: granted {} new unlock-notify item(s)", granted);
+        grant::persist();
+    }
+}
+
+/// Grant the start items (Torrent, flasks, quick_start runes) EXACTLY ONCE per save. They are NOT
+/// replayed through the received-item stream, so re-queuing on every reconnect would duplicate them;
+/// the persisted `start_items_granted` flag gates the whole queue. (`pendingStartItems` drain.)
+fn drain_start_items() {
+    let mut q = pending_start_items().lock().unwrap();
+    if q.is_empty() {
+        return;
+    }
+    if grant::start_items_granted() {
+        // Connect filled the queue before the persisted flag was loaded; this save already has them.
+        tracing::info!("Start items: already granted this save; dropping {} re-queued item(s)", q.len());
+        q.clear();
+        return;
+    }
+    // Need an inventory pointer to grant; if not captured yet, leave the queue and retry next tick.
+    let snapshot: Vec<(i32, i32)> = q.iter().copied().collect();
+    let mut any = false;
+    for &(id, ct) in &snapshot {
+        if detour::grant_full_id(id, ct) {
+            any = true;
+        } else {
+            return; // retry whole queue next tick (no partial once-per-save state)
+        }
+    }
+    if any {
+        tracing::info!("Start items: granted {} once-per-save item(s)", snapshot.len());
+        q.clear();
+        grant::set_start_items_granted();
+        grant::persist();
+    }
+}
+
+/// Map reveal under map_option=give: set every region's reveal flag directly (no map items granted).
+/// One-shot per connect, retried until the flag holder is ready. (`revealAllMaps`.)
+fn reveal_maps_if_pending() {
+    if !REVEAL_MAPS_PENDING.load(Ordering::Relaxed) {
+        return;
+    }
+    let include_dlc = config().lock().unwrap().enable_dlc;
+    let mut any = false;
+    for &(map_id, flag) in MAP_UNLOCK_FLAGS {
+        if !include_dlc && map_id >= 2_000_000 {
+            continue; // DLC map; skip when DLC off
+        }
+        if !flags::try_set_event_flag(flag, true) {
+            return; // holder not ready; retry next tick (one shared holder for all)
+        }
+        any = true;
+        tracing::info!("reveal_all_maps: map {} reveal flag {} SET", map_id, flag);
+    }
+    if any {
+        REVEAL_MAPS_PENDING.store(false, Ordering::Relaxed);
+    }
+}
+
+/// Set any queued grace warp-unlock / region-open / map-reveal / acquisition flags. SetEventFlag is
+/// idempotent + save-persisted, so re-applying on reconnect/replay is harmless; a flag whose holder
+/// isn't ready is re-queued. (`CCore::FlushPendingGraceFlags`.)
+fn flush_grace_flags() {
+    let mut q = pending_grace_flags().lock().unwrap();
+    if q.is_empty() {
+        return;
+    }
+    let mut session = grace_set_this_session().lock().unwrap();
+    let mut retry: VecDeque<u32> = VecDeque::new();
+    let mut set_count = 0;
+    while let Some(flag) = q.pop_front() {
+        if session.contains(&flag) {
+            continue; // already set this session
+        }
+        if flags::try_set_event_flag(flag, true) {
+            session.insert(flag);
+            set_count += 1;
+            tracing::info!("Region grace flag {} SET", flag);
+        } else {
+            retry.push_back(flag); // holder not ready; try next tick
+        }
+    }
+    *q = retry;
+    if set_count > 0 {
+        tracing::info!("Region fusion: set {} grace flag(s) ({} pending)", set_count, q.len());
+    }
+}
+
+/// Bloom regions whose vanilla-trigger DISJUNCTION is now satisfied. A clause is satisfied when all
+/// its items were received AND all its flags are set; ANY clause fires. The region open flag doubles
+/// as the once-latch. Reads event flags, so it MUST run on the settled tick.
+/// (`CCore::EvaluateNaturalKeyTriggers`.)
+fn evaluate_natural_key_triggers() {
+    let cfg = config().lock().unwrap();
+    if cfg.natural_key_triggers.is_empty() {
+        return;
+    }
+    let names = received_names().lock().unwrap();
+    let mut graces = pending_grace_flags().lock().unwrap();
+    let mut notify = pending_notify_grants().lock().unwrap();
+
+    for (name, clauses) in &cfg.natural_key_triggers {
+        // Guard: needs an open flag, and that flag not already set (latch).
+        let open_flag = match cfg.region_open_flags.get(name) {
+            Some(&f) => f,
+            None => continue,
+        };
+        if flags::get_event_flag(open_flag) {
+            continue; // already bloomed
+        }
+        // Any clause satisfied?
+        let fired = clauses.iter().any(|cl| {
+            cl.items.iter().all(|nm| names.contains(nm))
+                && cl.flags.iter().all(|&fl| flags::get_event_flag(fl))
+        });
+        if !fired {
+            continue;
+        }
+        // BLOOM: queue grace + open + reveal flags (+ notify item).
+        let mut queued = 0;
+        if let Some(fs) = cfg.region_graces.get(name) {
+            for &f in fs {
+                graces.push_back(f);
+                queued += 1;
+            }
+        }
+        graces.push_back(open_flag);
+        queued += 1;
+        if let Some(fs) = cfg.lock_reveal_flags.get(name) {
+            for &f in fs {
+                graces.push_back(f);
+                queued += 1;
+            }
+        }
+        if let Some(&addr) = cfg.lock_notify_items.get(name) {
+            notify.push_back(addr);
+        }
+        tracing::info!("Natural-key '{}' satisfied: bloomed region ({} flag(s) queued)", name, queued);
+    }
+}
+
+/// Detect checks whose acquisition bypassed the AddItemFunc detour (shop buys, NPC gifts, offline
+/// pickups) by polling each AP location's guarding event flag, plus dungeon + boss/grace sweeps.
+/// (`CCore::PollLocationFlags`.) Reports via `flags::report_location` (the net thread sends).
+fn poll_location_flags() {
+    let cfg = config().lock().unwrap();
+    if cfg.location_flags.is_empty() && cfg.sweep_flags.is_empty() {
+        return;
+    }
+    let mut sent = grace_sent_guard();
+
+    // Per-location flag poll.
+    let mut n = 0;
+    for (&loc, &flag) in &cfg.location_flags {
+        if sent.contains(&loc) {
+            continue;
+        }
+        if !flags::get_event_flag(flag) {
+            continue;
+        }
+        sent.insert(loc);
+        flags::report_location(loc);
+        n += 1;
+    }
+    if n > 0 {
+        tracing::info!("Flag polling: sent {} location check(s)", n);
+    }
+
+    // Dungeon sweep: when a dungeon's trigger (boss-drop) flag fires, send every remaining member.
+    for (trigger, members) in &cfg.dungeon_sweeps {
+        let flag = match cfg.location_flags.get(trigger) {
+            Some(&f) => f,
+            None => continue,
+        };
+        if !flags::get_event_flag(flag) {
+            continue;
+        }
+        let mut swept = 0;
+        for &m in members {
+            if sent.insert(m) {
+                flags::report_location(m);
+                swept += 1;
+            }
+        }
+        if swept > 0 {
+            tracing::info!("Dungeon sweep: trigger {} cleared {} remaining check(s)", trigger, swept);
+        }
+    }
+
+    // Boss/grace attribution sweep: sweep_flags is keyed by the event flag itself. Skip graces the
+    // CLIENT force-lit this session (start graces / region bundles) — sweeping those dumps checks at
+    // spawn; boss DefeatFlags are never client-set, so the boss sweep is unaffected.
+    let session = grace_set_this_session().lock().unwrap();
+    for (&flag, members) in &cfg.sweep_flags {
+        if session.contains(&flag) {
+            continue;
+        }
+        if !flags::get_event_flag(flag) {
+            continue;
+        }
+        let mut swept = 0;
+        for &m in members {
+            if sent.insert(m) {
+                flags::report_location(m);
+                swept += 1;
+            }
+        }
+        if swept > 0 {
+            tracing::info!("Boss/grace sweep: flag {} cleared {} check(s)", flag, swept);
+        }
+    }
+}
+
+/// Borrow the flag-sent set; split out so `poll_location_flags` reads naturally.
+fn grace_sent_guard() -> std::sync::MutexGuard<'static, HashSet<i64>> {
+    flag_sent_locations().lock().unwrap()
+}
+
+/// Warp latches + region-lock KICK enforcement. Reads the player's area id and, once per entry, sets
+/// the baked DLC/random-start warp flags and the KICK flag for a locked region. (`CCore::Run` block.)
+fn warp_and_lock_latches() {
+    static KICK_LATCHED: AtomicBool = AtomicBool::new(false);
+    static DLC_LATCHED: AtomicBool = AtomicBool::new(false);
+    static START_LATCHED: AtomicBool = AtomicBool::new(false);
+
+    let pr = match flags::play_region_id() {
+        Some(p) => p,
+        None => return,
+    };
+    let cfg = config().lock().unwrap();
+
+    // --- region-lock KICK (76970) ---
+    // Normalize: overworld sub-areas report a 7-digit id (subregion*100); the major area reports the
+    // 5-digit subregion. Reduce to the 5-digit subregion for the range match.
+    let sub = if pr >= 1_000_000 { pr / 100 } else { pr };
+    let locked = cfg.area_lock_flags.iter().any(|e| {
+        sub >= e[0] && sub <= e[1] && !flags::get_event_flag(e[2] as u32)
+    });
+    if !locked {
+        KICK_LATCHED.store(false, Ordering::Relaxed);
+    } else if !KICK_LATCHED.load(Ordering::Relaxed) {
+        // Start-window guard: on a random-start seed the player transiently spawns in (locked)
+        // Limgrave before the baked warp pulls them out; don't arm KICK until the random-start warp
+        // has fired. Non-random seeds (done flag 0) => guard always true => unchanged.
+        let guard_ok = cfg.random_start_done_flag == 0
+            || flags::get_event_flag(cfg.random_start_done_flag);
+        if guard_ok {
+            KICK_LATCHED.store(true, Ordering::Relaxed);
+            flags::set_event_flag(KICK_FLAG, true);
+            tracing::info!("RegionLock: area={} LOCKED -> KICK", pr);
+        }
+    }
+
+    // --- DLC auto-entry: on the intro Chapel, set the baked entry flag ONCE -> warp to Gravesite ---
+    if cfg.dlc_entry_warp_flag != 0
+        && cfg.dlc_start_area_id != 0
+        && pr == cfg.dlc_start_area_id
+        && !flags::get_event_flag(DLC_ENTERED_FLAG)
+        && !DLC_LATCHED.swap(true, Ordering::Relaxed)
+    {
+        flags::set_event_flag(cfg.dlc_entry_warp_flag, true);
+        tracing::info!("DLC auto-entry: in start area {} -> set flag {}", pr, cfg.dlc_entry_warp_flag);
+    }
+
+    // --- Random starting region: same latch, for the rolled start region ---
+    if cfg.random_start_warp_flag != 0
+        && cfg.random_start_area_id != 0
+        && cfg.random_start_done_flag != 0
+        && pr == cfg.random_start_area_id
+        && !flags::get_event_flag(cfg.random_start_done_flag)
+        && !START_LATCHED.swap(true, Ordering::Relaxed)
+    {
+        flags::set_event_flag(cfg.random_start_done_flag, true);
+        flags::set_event_flag(cfg.random_start_warp_flag, true);
+        tracing::info!("Random start: in area {} -> set flag {}", pr, cfg.random_start_warp_flag);
+    }
+}
+
+/// Called from `grant.rs` after granting an INDEX-STREAM item (the received-item queue, not the
+/// notify queue): if it's a map fragment, also set its map-reveal flag. (`GiveNextItem` map branch.)
+pub fn on_index_grant(full_id: i32) {
+    if (full_id & 0xF000_0000u32 as i32) != GOODS_FULLID {
+        return;
+    }
+    let base = full_id & 0x0FFF_FFFF;
+    if let Some(&(_, flag)) = MAP_UNLOCK_FLAGS.iter().find(|(id, _)| *id == base) {
+        let ok = flags::try_set_event_flag(flag, true);
+        tracing::info!("Map fragment {}: reveal flag {} {}", base, flag, if ok { "SET" } else { "FAILED (holder not ready)" });
+    }
+}

--- a/crates/eldenring-archipelago/src/game/features.rs
+++ b/crates/eldenring-archipelago/src/game/features.rs
@@ -46,7 +46,7 @@ pub struct SlotConfig {
     pub grace_items: HashMap<String, u32>,        // grace item -> one warp flag
     pub region_open_flags: HashMap<String, u32>,  // lock item -> one physical region-open flag
     pub lock_reveal_flags: HashMap<String, Vec<u32>>, // lock item -> map-reveal/open flags
-    pub lock_notify_items: HashMap<String, i32>,  // lock item -> FullID granted as the unlock notice
+    pub lock_notify_items: HashMap<String, i32>, // lock item -> FullID granted as the unlock notice
     pub natural_key_triggers: HashMap<String, Vec<NkClause>>, // region -> clause disjunction
 
     // --- warp latches (game-state -> set a baked warp flag once) ---
@@ -64,7 +64,7 @@ pub struct SlotConfig {
     pub enable_dlc: bool,
 
     // --- check polling (acquisitions that bypass the AddItemFunc detour) ---
-    pub location_flags: HashMap<i64, u32>,  // apconfig: AP location id -> guarding event flag
+    pub location_flags: HashMap<i64, u32>, // apconfig: AP location id -> guarding event flag
     pub sweep_flags: HashMap<u32, Vec<i64>>, // apconfig: event flag -> AP location ids
     pub dungeon_sweeps: HashMap<i64, Vec<i64>>, // slot_data: trigger location -> member locations
 }
@@ -164,13 +164,25 @@ const GOODS_FULLID: i32 = 0x4000_0000u32 as i32;
 /// region map stays fogged until this separate flag is set (vanilla pickup events set both).
 /// Base ids < 2_000_000; DLC (Land of Shadow) pieces are the `2008600..` block (skipped when DLC off).
 const MAP_UNLOCK_FLAGS: &[(i32, u32)] = &[
-    (8600, 62010), (8601, 62011), (8602, 62012), // Limgrave W, Weeping, Limgrave E
-    (8603, 62020), (8604, 62021), (8605, 62022), // Liurnia E/N/W
-    (8606, 62030), (8607, 62031), (8608, 62032), // Altus, Leyndell, Gelmir
-    (8609, 62040), (8610, 62041),                // Caelid, Dragonbarrow
-    (8611, 62050), (8612, 62051), (8618, 62052), // Mountaintops W/E, Snowfield
-    (8613, 62060), (8614, 62061), (8616, 62062), // Ainsel, Lake of Rot, Mohgwyn
-    (8615, 62063), (8617, 62064),                // Siofra, Deeproot
+    (8600, 62010),
+    (8601, 62011),
+    (8602, 62012), // Limgrave W, Weeping, Limgrave E
+    (8603, 62020),
+    (8604, 62021),
+    (8605, 62022), // Liurnia E/N/W
+    (8606, 62030),
+    (8607, 62031),
+    (8608, 62032), // Altus, Leyndell, Gelmir
+    (8609, 62040),
+    (8610, 62041), // Caelid, Dragonbarrow
+    (8611, 62050),
+    (8612, 62051),
+    (8618, 62052), // Mountaintops W/E, Snowfield
+    (8613, 62060),
+    (8614, 62061),
+    (8616, 62062), // Ainsel, Lake of Rot, Mohgwyn
+    (8615, 62063),
+    (8617, 62064),    // Siofra, Deeproot
     (2008600, 62080), // Gravesite Plain  (WorldMapPieceParam 1000)
     (2008601, 62081), // Scadu Altus      (1001)
     (2008602, 62082), // Southern Shore   (1002)
@@ -224,7 +236,10 @@ pub fn enqueue_start_grace(flag: u32) {
 
 /// Net thread: parse-time helper so net.rs can push a once-per-save start item (FullID, count).
 pub fn enqueue_start_item(full_id: i32, count: i32) {
-    pending_start_items().lock().unwrap().push_back((full_id, count.max(1)));
+    pending_start_items()
+        .lock()
+        .unwrap()
+        .push_back((full_id, count.max(1)));
 }
 
 /// Net thread: dispatch ONE received item by NAME (idempotent — safe to call for the full replay on
@@ -245,7 +260,11 @@ pub fn on_item_received(name: &str) {
         for &f in fs {
             graces.push_back(f);
         }
-        tracing::info!("Region lock '{}' received: queued {} grace flag(s)", name, fs.len());
+        tracing::info!(
+            "Region lock '{}' received: queued {} grace flag(s)",
+            name,
+            fs.len()
+        );
     }
     // Grace rando: grace item -> one warp flag.
     if let Some(&f) = cfg.grace_items.get(name) {
@@ -255,14 +274,22 @@ pub fn on_item_received(name: &str) {
     // Region-open (physical fog gate): lock item -> one open flag.
     if let Some(&f) = cfg.region_open_flags.get(name) {
         graces.push_back(f);
-        tracing::info!("Region lock '{}' received: queued region-open flag {}", name, f);
+        tracing::info!(
+            "Region lock '{}' received: queued region-open flag {}",
+            name,
+            f
+        );
     }
     // Generalized reveal/open: lock item -> map-reveal + enforcement-open flags.
     if let Some(fs) = cfg.lock_reveal_flags.get(name) {
         for &f in fs {
             graces.push_back(f);
         }
-        tracing::info!("Region lock '{}' received: queued {} reveal/open flag(s)", name, fs.len());
+        tracing::info!(
+            "Region lock '{}' received: queued {} reveal/open flag(s)",
+            name,
+            fs.len()
+        );
     }
     // Unlock notification item (map fragment / token) -> once-per-save grant queue.
     if let Some(&addr) = cfg.lock_notify_items.get(name) {
@@ -274,19 +301,35 @@ pub fn on_item_received(name: &str) {
         for &f in fs {
             graces.push_back(f);
         }
-        tracing::info!("Companion item '{}' received: queued {} acquisition flag(s)", name, fs.len());
+        tracing::info!(
+            "Companion item '{}' received: queued {} acquisition flag(s)",
+            name,
+            fs.len()
+        );
     }
     // Key-item acquisition flags.
     if let Some(fs) = lookup(KEY_ITEM_ACQUIRE_FLAGS, name) {
         for &f in fs {
             graces.push_back(f);
         }
-        tracing::info!("Key item '{}' received: queued {} obtained-flag(s)", name, fs.len());
+        tracing::info!(
+            "Key item '{}' received: queued {} obtained-flag(s)",
+            name,
+            fs.len()
+        );
     }
     // Great-rune restore: ADDITIONALLY grant the "(Restored)" goods row (once per save via notify).
-    if let Some(goods) = GREAT_RUNE_RESTORE_GOODS.iter().find(|(n, _)| *n == name).map(|(_, g)| *g) {
+    if let Some(goods) = GREAT_RUNE_RESTORE_GOODS
+        .iter()
+        .find(|(n, _)| *n == name)
+        .map(|(_, g)| *g)
+    {
         notify.push_back((goods as i32) | GOODS_FULLID);
-        tracing::info!("Great rune '{}' received: also granting restored goods {} (usable now)", name, goods);
+        tracing::info!(
+            "Great rune '{}' received: also granting restored goods {} (usable now)",
+            name,
+            goods
+        );
     }
 }
 
@@ -371,7 +414,10 @@ fn drain_start_items() {
     }
     if grant::start_items_granted() {
         // Connect filled the queue before the persisted flag was loaded; this save already has them.
-        tracing::info!("Start items: already granted this save; dropping {} re-queued item(s)", q.len());
+        tracing::info!(
+            "Start items: already granted this save; dropping {} re-queued item(s)",
+            q.len()
+        );
         q.clear();
         return;
     }
@@ -386,7 +432,10 @@ fn drain_start_items() {
         }
     }
     if any {
-        tracing::info!("Start items: granted {} once-per-save item(s)", snapshot.len());
+        tracing::info!(
+            "Start items: granted {} once-per-save item(s)",
+            snapshot.len()
+        );
         q.clear();
         grant::set_start_items_granted();
         grant::persist();
@@ -441,7 +490,11 @@ fn flush_grace_flags() {
     }
     *q = retry;
     if set_count > 0 {
-        tracing::info!("Region fusion: set {} grace flag(s) ({} pending)", set_count, q.len());
+        tracing::info!(
+            "Region fusion: set {} grace flag(s) ({} pending)",
+            set_count,
+            q.len()
+        );
     }
 }
 
@@ -494,7 +547,11 @@ fn evaluate_natural_key_triggers() {
         if let Some(&addr) = cfg.lock_notify_items.get(name) {
             notify.push_back(addr);
         }
-        tracing::info!("Natural-key '{}' satisfied: bloomed region ({} flag(s) queued)", name, queued);
+        tracing::info!(
+            "Natural-key '{}' satisfied: bloomed region ({} flag(s) queued)",
+            name,
+            queued
+        );
     }
 }
 
@@ -542,7 +599,11 @@ fn poll_location_flags() {
             }
         }
         if swept > 0 {
-            tracing::info!("Dungeon sweep: trigger {} cleared {} remaining check(s)", trigger, swept);
+            tracing::info!(
+                "Dungeon sweep: trigger {} cleared {} remaining check(s)",
+                trigger,
+                swept
+            );
         }
     }
 
@@ -592,17 +653,18 @@ fn warp_and_lock_latches() {
     // Normalize: overworld sub-areas report a 7-digit id (subregion*100); the major area reports the
     // 5-digit subregion. Reduce to the 5-digit subregion for the range match.
     let sub = if pr >= 1_000_000 { pr / 100 } else { pr };
-    let locked = cfg.area_lock_flags.iter().any(|e| {
-        sub >= e[0] && sub <= e[1] && !flags::get_event_flag(e[2] as u32)
-    });
+    let locked = cfg
+        .area_lock_flags
+        .iter()
+        .any(|e| sub >= e[0] && sub <= e[1] && !flags::get_event_flag(e[2] as u32));
     if !locked {
         KICK_LATCHED.store(false, Ordering::Relaxed);
     } else if !KICK_LATCHED.load(Ordering::Relaxed) {
         // Start-window guard: on a random-start seed the player transiently spawns in (locked)
         // Limgrave before the baked warp pulls them out; don't arm KICK until the random-start warp
         // has fired. Non-random seeds (done flag 0) => guard always true => unchanged.
-        let guard_ok = cfg.random_start_done_flag == 0
-            || flags::get_event_flag(cfg.random_start_done_flag);
+        let guard_ok =
+            cfg.random_start_done_flag == 0 || flags::get_event_flag(cfg.random_start_done_flag);
         if guard_ok {
             KICK_LATCHED.store(true, Ordering::Relaxed);
             flags::set_event_flag(KICK_FLAG, true);
@@ -618,7 +680,11 @@ fn warp_and_lock_latches() {
         && !DLC_LATCHED.swap(true, Ordering::Relaxed)
     {
         flags::set_event_flag(cfg.dlc_entry_warp_flag, true);
-        tracing::info!("DLC auto-entry: in start area {} -> set flag {}", pr, cfg.dlc_entry_warp_flag);
+        tracing::info!(
+            "DLC auto-entry: in start area {} -> set flag {}",
+            pr,
+            cfg.dlc_entry_warp_flag
+        );
     }
 
     // --- Random starting region: same latch, for the rolled start region ---
@@ -631,7 +697,11 @@ fn warp_and_lock_latches() {
     {
         flags::set_event_flag(cfg.random_start_done_flag, true);
         flags::set_event_flag(cfg.random_start_warp_flag, true);
-        tracing::info!("Random start: in area {} -> set flag {}", pr, cfg.random_start_warp_flag);
+        tracing::info!(
+            "Random start: in area {} -> set flag {}",
+            pr,
+            cfg.random_start_warp_flag
+        );
     }
 }
 
@@ -644,6 +714,15 @@ pub fn on_index_grant(full_id: i32) {
     let base = full_id & 0x0FFF_FFFF;
     if let Some(&(_, flag)) = MAP_UNLOCK_FLAGS.iter().find(|(id, _)| *id == base) {
         let ok = flags::try_set_event_flag(flag, true);
-        tracing::info!("Map fragment {}: reveal flag {} {}", base, flag, if ok { "SET" } else { "FAILED (holder not ready)" });
+        tracing::info!(
+            "Map fragment {}: reveal flag {} {}",
+            base,
+            flag,
+            if ok {
+                "SET"
+            } else {
+                "FAILED (holder not ready)"
+            }
+        );
     }
 }

--- a/crates/eldenring-archipelago/src/game/flags.rs
+++ b/crates/eldenring-archipelago/src/game/flags.rs
@@ -1,0 +1,109 @@
+//! REPORT layer — getting checks to the AP server, and event-flag read/set.
+//!
+//! Two jobs that were `CSEventFlagMan` + the protocol layer in C++:
+//!   1. A check was observed (in the detour) -> hand its AP location id to the network thread.
+//!   2. Detect checks whose acquisition BYPASSES the detour (shop buys, NPC gifts, offline
+//!      pickups) by polling each location's guarding event flag (apconfig.json "location_flags"),
+//!      and set collected/grace/region flags (region fusion, map reveal, DLC-entry warps, ...).
+//!
+//! ⚠️ COMPILE-TARGET SKETCH (not yet built). Symbols RESOLVED against eldenring 0.14 —
+//! see the spike root's VERIFY-RESOLUTION.md. The flag get/set + region-id accessors below are wired.
+
+use std::sync::mpsc::{Receiver, SyncSender};
+use std::sync::OnceLock;
+
+use eldenring::cs::{CSEventFlagMan, WorldChrMan};
+use fromsoftware_shared::FromStatic;
+
+/// Bounded queue of AP location ids observed on the game thread, drained by the network thread and
+/// sent as `LocationChecks`. Mirrors the C++ cross-thread `checkedLocationsList`, but a real
+/// channel instead of a no-lock shared vec (removes a latent race the C++ comments hand-wave).
+struct ReportChannel {
+    tx: SyncSender<i64>,
+    rx: std::sync::Mutex<Receiver<i64>>,
+}
+
+fn channel() -> &'static ReportChannel {
+    static CH: OnceLock<ReportChannel> = OnceLock::new();
+    CH.get_or_init(|| {
+        let (tx, rx) = std::sync::mpsc::sync_channel(4096);
+        ReportChannel {
+            tx,
+            rx: std::sync::Mutex::new(rx),
+        }
+    })
+}
+
+/// Called from the detour (game thread): enqueue a check. Never blocks the game; drops with a warn
+/// if the queue is somehow full (network thread wedged).
+pub fn report_location(ap_location_id: i64) {
+    if channel().tx.try_send(ap_location_id).is_err() {
+        tracing::warn!("report queue full; dropped location {ap_location_id}");
+    }
+}
+
+/// Called from the network thread: drain everything observed since last poll, to batch into one
+/// `LocationChecks`.
+#[allow(dead_code)]
+pub fn drain_reported() -> Vec<i64> {
+    let rx = channel().rx.lock().unwrap();
+    rx.try_iter().collect()
+}
+
+// --- event flags (er_hooks.h EventFlag_* / er_singletons.h CSEventFlagMan) ------------------------
+
+/// Read an event flag (true = set). Used to detect detour-bypassing acquisitions and as the
+/// region/natural-key latch. Safe before the flag holder initializes: returns false.
+#[allow(dead_code)]
+pub fn get_event_flag(flag_id: u32) -> bool {
+    // RESOLVED: get/set live on `CSEventFlagMan.virtual_memory_flag` (type CSFD4VirtualMemoryFlag),
+    // taking `impl Into<EventFlag>` (a u32 auto-converts) — NOT a `get_event_flag` on the manager.
+    // Returns false before the manager initializes.
+    match unsafe { CSEventFlagMan::instance() } {
+        Ok(m) => m.virtual_memory_flag.get_flag(flag_id),
+        Err(_) => false,
+    }
+}
+
+/// Set an event flag. Idempotent + game-save-persisted, so re-running on reconnect/replay is
+/// harmless (the C++ relied on exactly this for grace/region/map-reveal flags).
+#[allow(dead_code)]
+pub fn set_event_flag(flag_id: u32, enabled: bool) {
+    let _ = try_set_event_flag(flag_id, enabled);
+}
+
+/// Set an event flag, returning whether the flag HOLDER was ready (true = set, false = retry later).
+/// Phase 5's FlushPendingGraceFlags / revealAllMaps need this: a flag set before CSEventFlagMan is
+/// up is silently dropped by new-game init, so the queue must re-try until the holder exists
+/// (mirrors the C++ `SetEventFlag` BOOL return). Idempotent + save-persisted once it does land.
+#[allow(dead_code)]
+pub fn try_set_event_flag(flag_id: u32, enabled: bool) -> bool {
+    // RESOLVED: `set_flag(impl Into<EventFlag>, bool)` on the virtual_memory_flag.
+    match unsafe { CSEventFlagMan::instance_mut() } {
+        Ok(m) => {
+            m.virtual_memory_flag.set_flag(flag_id, enabled);
+            true
+        }
+        Err(_) => {
+            tracing::debug!("set_event_flag({flag_id}, {enabled}): CSEventFlagMan not up yet");
+            false
+        }
+    }
+}
+
+/// Player's current `PlayRegionId` (region-lock physical enforcement), or `None` if not in-world.
+/// C++ read `FieldArea + 0xE4`; the crate exposes this via the field-area singleton.
+#[allow(dead_code)]
+pub fn play_region_id() -> Option<i32> {
+    // RESOLVED: there is NO CSFieldArea region accessor. Current region =
+    // WorldChrMan.main_player -> PlayerIns.play_region_id (u32). None if not in-world.
+    let wcm = unsafe { WorldChrMan::instance() }.ok()?;
+    Some(wcm.main_player.as_ref()?.play_region_id as i32)
+}
+
+/// True once the player is loaded into the world (WorldChrMan.main_player present). Used to gate
+/// param-table access: at the first frames during boot the params aren't populated and iterating
+/// EquipParamGoods faults, but in-world they are guaranteed loaded.
+pub fn in_world() -> bool {
+    play_region_id().is_some()
+}

--- a/crates/eldenring-archipelago/src/game/grant.rs
+++ b/crates/eldenring-archipelago/src/game/grant.rs
@@ -1,0 +1,236 @@
+//! Phase 4 — server-pushed item GRANT queue + `last_received_index` persistence.
+//!
+//! The `AddItemFunc` detour (detour.rs) grants LOCAL self-found pickups by rewriting the descriptor
+//! in place. Items the SERVER sends (`items_received`) never pass through a pickup, so they must be
+//! granted by CONSTRUCTING an itembuf and calling the original AddItemFunc — `detour::grant_full_id`.
+//!
+//! Threading: the AP net thread (net.rs) `enqueue()`s decoded items; the FrameBegin game tick calls
+//! `drain_and_grant()`, which is the ONLY place that touches game inventory. Mirrors the C++
+//! ItemRandomiser `receivedItemsQueue` + `CGameHook::GiveNextItem` + `CCore::WriteSaveFile`.
+//!
+//! Persistence (single-owner = game thread): `PERSIST_INDEX` is the highest received-item index that
+//! has actually been GRANTED, written to `archipelago/<seed>_<slot>.json` after each grant. The net
+//! thread READS this file once at (re)connect to know where to resume, so a crash before a grant
+//! replays the item on reconnect (no double-grant, no loss) — the server re-sends everything under
+//! items_handling 0b111.
+
+use std::collections::{HashSet, VecDeque};
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
+use std::sync::mpsc::{Receiver, SyncSender};
+use std::sync::{Mutex, OnceLock};
+
+use super::detour;
+use super::features;
+use super::flags;
+use super::progressive;
+
+/// One server-pushed item to grant in-game.
+pub struct GrantMsg {
+    /// ER FullID (real item id | category nibble) — already category-tagged by the apworld map.
+    pub full_id: i32,
+    pub qty: i32,
+    /// Global received-item index (the persisted dedup watermark).
+    pub ap_index: i64,
+    /// AP item name (logging today; on-screen notifications are Phase 5 / open-piece 3).
+    pub name: String,
+}
+
+struct GrantChannel {
+    tx: SyncSender<GrantMsg>,
+    rx: Mutex<Receiver<GrantMsg>>,
+}
+
+fn channel() -> &'static GrantChannel {
+    static CH: OnceLock<GrantChannel> = OnceLock::new();
+    CH.get_or_init(|| {
+        let (tx, rx) = std::sync::mpsc::sync_channel(4096);
+        GrantChannel { tx, rx: Mutex::new(rx) }
+    })
+}
+
+/// Items popped off the channel but not yet granted (inventory pointer not captured yet). The game
+/// thread is the only accessor; held so nothing is lost while we wait for the player's first pickup.
+fn pending() -> &'static Mutex<VecDeque<GrantMsg>> {
+    static P: OnceLock<Mutex<VecDeque<GrantMsg>>> = OnceLock::new();
+    P.get_or_init(|| Mutex::new(VecDeque::new()))
+}
+
+static SAVE_PATH: OnceLock<PathBuf> = OnceLock::new();
+/// Highest received-item index GRANTED in-game (persisted). -1 = not configured (pre-connect).
+static PERSIST_INDEX: AtomicI64 = AtomicI64::new(-1);
+
+// --- Phase 5 persisted state (extends the save file alongside last_received_index) ---------------
+/// Start items (Torrent, flasks, quick_start runes) granted for THIS save (once-per-save gate).
+static START_ITEMS_GRANTED: AtomicBool = AtomicBool::new(false);
+/// FullIDs of unlock-notify items / great-rune restores already granted this save (once-per-save).
+fn notify_granted() -> &'static Mutex<HashSet<i32>> {
+    static S: OnceLock<Mutex<HashSet<i32>>> = OnceLock::new();
+    S.get_or_init(|| Mutex::new(HashSet::new()))
+}
+
+/// Phase 5: has the start-item bundle been granted for this save? (`startItemsGranted`.)
+pub fn start_items_granted() -> bool {
+    START_ITEMS_GRANTED.load(Ordering::Relaxed)
+}
+/// Phase 5: mark the start-item bundle granted (persisted on the next `persist()`).
+pub fn set_start_items_granted() {
+    START_ITEMS_GRANTED.store(true, Ordering::Relaxed);
+}
+/// Phase 5: was this notify FullID already granted this save? (`notifyGrantedAddrs`.)
+pub fn notify_already_granted(addr: i32) -> bool {
+    notify_granted().lock().unwrap().contains(&addr)
+}
+/// Phase 5: record a notify FullID as granted (persisted on the next `persist()`).
+pub fn note_notify_granted(addr: i32) {
+    notify_granted().lock().unwrap().insert(addr);
+}
+/// Phase 5: force a save-file write now (called by features after once-per-save grants land).
+pub fn persist() {
+    write_save();
+}
+
+/// net thread: enqueue a server-pushed item for the game thread to grant. Never blocks the net loop.
+pub fn enqueue(msg: GrantMsg) {
+    if channel().tx.try_send(msg).is_err() {
+        tracing::warn!("grant queue full; dropped a received item (game tick wedged?)");
+    }
+}
+
+/// net thread, at (re)connect: record the per-seed save path and the resume index loaded from it,
+/// and restore the Phase-5 once-per-save state (start_items_granted, notify_granted) from the file.
+pub fn configure(save_path: PathBuf, start_index: i64) {
+    if let Ok(text) = std::fs::read_to_string(&save_path) {
+        if let Ok(v) = serde_json::from_str::<serde_json::Value>(&text) {
+            START_ITEMS_GRANTED.store(
+                v.get("start_items_granted").and_then(|x| x.as_bool()).unwrap_or(false),
+                Ordering::Relaxed,
+            );
+            if let Some(arr) = v.get("notify_granted").and_then(|x| x.as_array()) {
+                let mut set = notify_granted().lock().unwrap();
+                for a in arr {
+                    if let Some(n) = a.as_i64() {
+                        set.insert(n as i32);
+                    }
+                }
+            }
+            // Phase 5 Wave C: restore the progressive tier counters + high-index (progressive.rs
+            // owns the live state; the save file is grant.rs's, so it round-trips them here).
+            progressive::restore(
+                v.get("progressive_counter").unwrap_or(&serde_json::Value::Null),
+                v.get("progressive_high_index").and_then(|x| x.as_i64()).unwrap_or(-1),
+            );
+        }
+    }
+    let _ = SAVE_PATH.set(save_path); // first connect wins; reconnects reuse the same path
+    PERSIST_INDEX.store(start_index, Ordering::Relaxed);
+}
+
+/// The highest received-item index granted so far (the net thread's resume watermark mirror).
+pub fn persisted_index() -> i64 {
+    PERSIST_INDEX.load(Ordering::Relaxed)
+}
+
+/// Game thread (FrameBegin tick): grant queued items. Gated on in-world AND a captured inventory
+/// pointer; un-grantable items stay queued (no index advance => no data loss within a session).
+pub fn drain_and_grant() {
+    if PERSIST_INDEX.load(Ordering::Relaxed) < 0 {
+        return; // not connected / slot_data not parsed yet
+    }
+    if !flags::in_world() {
+        return; // params/inventory not loaded; the detour hasn't captured an inventory pointer
+    }
+
+    let mut q = pending().lock().unwrap();
+    // Move everything currently in the channel into the ordered pending buffer.
+    {
+        let rx = channel().rx.lock().unwrap();
+        for msg in rx.try_iter() {
+            q.push_back(msg);
+        }
+    }
+    if q.is_empty() {
+        return;
+    }
+
+    let mut advanced = false;
+    while let Some(msg) = q.front() {
+        // Defensive replay dedup (the net thread already filters, but be safe across reconnects).
+        if msg.ap_index < PERSIST_INDEX.load(Ordering::Relaxed) {
+            q.pop_front();
+            continue;
+        }
+        // Logic-only region-lock keys carry sentinel er_code 99999/99998 and have no real param row;
+        // granting them would hand the game a nonexistent goods row. Skip the grant, advance the
+        // index (so they don't replay). Mirrors CGameHook::GiveNextItem.
+        let row = (msg.full_id as u32) & 0x0FFF_FFFF;
+        let granted = if row == 99_999 || row == 99_998 {
+            tracing::info!("received sentinel item '{}' (no in-game grant)", msg.name);
+            true
+        } else {
+            detour::grant_full_id(msg.full_id, msg.qty)
+        };
+
+        if !granted {
+            // No inventory pointer captured yet (no pickup this session). Leave THIS and the rest
+            // queued and retry next tick — do NOT advance the persisted index.
+            break;
+        }
+
+        tracing::info!(
+            "granted received item '{}' (FullID {:#010x} x{})",
+            msg.name,
+            msg.full_id as u32,
+            msg.qty
+        );
+        // Map fragments granted through the index stream also flip their map-REVEAL flag (the goods
+        // item alone leaves the region fogged). Port of the GiveNextItem map branch; no-op otherwise.
+        features::on_index_grant(msg.full_id);
+        let new_idx = msg.ap_index + 1;
+        if new_idx > PERSIST_INDEX.load(Ordering::Relaxed) {
+            PERSIST_INDEX.store(new_idx, Ordering::Relaxed);
+            advanced = true;
+        }
+        q.pop_front();
+    }
+    drop(q);
+
+    if advanced {
+        write_save();
+    }
+}
+
+/// Persist `{"last_received_index": N}` atomically (write `.swap`, then rename) so a crash/quit can't
+/// orphan the index. Mirrors CCore::WriteAtomic + WriteSaveFile.
+fn write_save() {
+    let path = match SAVE_PATH.get() {
+        Some(p) => p,
+        None => return,
+    };
+    let idx = PERSIST_INDEX.load(Ordering::Relaxed);
+    // Extends the Phase-4 single-field save with the Phase-5 once-per-save state. serde_json builds
+    // the object so the notify_granted list / bool escape correctly (mirrors CCore::WriteSaveFile).
+    let notify: Vec<i32> = notify_granted().lock().unwrap().iter().copied().collect();
+    let (prog_counter, prog_high) = progressive::snapshot();
+    let body = serde_json::json!({
+        "last_received_index": idx,
+        "start_items_granted": START_ITEMS_GRANTED.load(Ordering::Relaxed),
+        "notify_granted": notify,
+        "progressive_counter": prog_counter,
+        "progressive_high_index": prog_high,
+    })
+    .to_string();
+
+    let mut swap_os = std::ffi::OsString::from(path.as_os_str());
+    swap_os.push(".swap");
+    let swap = PathBuf::from(swap_os);
+
+    if std::fs::write(&swap, body.as_bytes()).is_err() {
+        tracing::warn!("save write failed: {:?}", swap);
+        return;
+    }
+    if let Err(e) = std::fs::rename(&swap, path) {
+        tracing::debug!("save rename failed ({e}); falling back to direct write");
+        let _ = std::fs::write(path, body.as_bytes());
+    }
+}

--- a/crates/eldenring-archipelago/src/game/grant.rs
+++ b/crates/eldenring-archipelago/src/game/grant.rs
@@ -45,7 +45,10 @@ fn channel() -> &'static GrantChannel {
     static CH: OnceLock<GrantChannel> = OnceLock::new();
     CH.get_or_init(|| {
         let (tx, rx) = std::sync::mpsc::sync_channel(4096);
-        GrantChannel { tx, rx: Mutex::new(rx) }
+        GrantChannel {
+            tx,
+            rx: Mutex::new(rx),
+        }
     })
 }
 
@@ -103,7 +106,9 @@ pub fn configure(save_path: PathBuf, start_index: i64) {
     if let Ok(text) = std::fs::read_to_string(&save_path) {
         if let Ok(v) = serde_json::from_str::<serde_json::Value>(&text) {
             START_ITEMS_GRANTED.store(
-                v.get("start_items_granted").and_then(|x| x.as_bool()).unwrap_or(false),
+                v.get("start_items_granted")
+                    .and_then(|x| x.as_bool())
+                    .unwrap_or(false),
                 Ordering::Relaxed,
             );
             if let Some(arr) = v.get("notify_granted").and_then(|x| x.as_array()) {
@@ -117,8 +122,11 @@ pub fn configure(save_path: PathBuf, start_index: i64) {
             // Phase 5 Wave C: restore the progressive tier counters + high-index (progressive.rs
             // owns the live state; the save file is grant.rs's, so it round-trips them here).
             progressive::restore(
-                v.get("progressive_counter").unwrap_or(&serde_json::Value::Null),
-                v.get("progressive_high_index").and_then(|x| x.as_i64()).unwrap_or(-1),
+                v.get("progressive_counter")
+                    .unwrap_or(&serde_json::Value::Null),
+                v.get("progressive_high_index")
+                    .and_then(|x| x.as_i64())
+                    .unwrap_or(-1),
             );
         }
     }

--- a/crates/eldenring-archipelago/src/game/mod.rs
+++ b/crates/eldenring-archipelago/src/game/mod.rs
@@ -1,0 +1,243 @@
+//! In-process / Windows-only glue for the ER Archipelago client.
+//!
+//! ⚠️ COMPILE-TARGET SKETCH, not yet built. The structure and the *confirmed* API calls
+//! (`CSTaskImp::wait_for_instance` + `run_recurring`, the me3 `DllMain` shape, the
+//! `EQUIP_PARAM_GOODS_ST` param struct, `retour`'s `static_detour!`) are taken from the real
+//! `eldenring` 0.14 docs + the fromsoftware-rs examples. Symbol spellings are now RESOLVED (see
+//! the spike root's VERIFY-RESOLUTION.md); what remains before this compiles is the AOB scan + grant
+//! construction in detour.rs. Build it on the Windows laptop (`cargo build --target x86_64-pc-windows-msvc`).
+//!
+//! This module replaces, in one place, what the C++ client spread across `er_hooks.h`,
+//! `er_singletons.h`, `er_gamehook_win.cpp`, and the `mem`/`minhook`/`fd4_singleton` subprojects.
+//! The *decisions* (what counts as synthetic, how to recombine the location id, grant-vs-suppress)
+//! stay in the pure, host-tested `er_codec` crate — this module only does the unsafe I/O.
+
+// This in-process module is the one place unsafe FFI lives (FD4 singleton access, the detour, raw
+// reads). The crate lint warns on `unsafe` to keep the pure shell clean; allow it HERE, where it's
+// expected and reviewed (matches the Cargo.toml intent). `dead_code` is allowed while the phase 3-5
+// feature surface is still being wired — handlers exist before their callers do; drop it once wired.
+#![allow(unsafe_code, dead_code)]
+
+#[cfg(feature = "detour")]
+mod console;
+#[cfg(feature = "detour")]
+mod detour;
+mod flags;
+mod params;
+
+// Phase 4 (AP networking). `net` implies `detour` (grants reuse the detour trampoline), so both
+// modules are present together. Off-by-default; build with `--features net`.
+#[cfg(feature = "net")]
+mod deathlink;
+#[cfg(feature = "net")]
+mod features;
+#[cfg(feature = "net")]
+mod grant;
+#[cfg(feature = "net")]
+mod net;
+#[cfg(feature = "net")]
+mod progressive;
+#[cfg(feature = "net")]
+mod upgrades;
+
+use std::time::Duration;
+
+// RESOLVED (apply-speffect example + docs.rs 0.14): CSTaskImp/CSTaskGroupIndex in `eldenring::cs`,
+// FD4TaskData in `eldenring::fd4`, SharedTaskImpExt re-exported at the `fromsoftware_shared` root.
+// `wait_for_instance` is a blocking INHERENT method on CSTaskImp (takes Duration, returns Result);
+// `run_recurring` is the ext-trait method and returns a handle that MUST be kept alive (see below).
+use eldenring::cs::{CSTaskGroupIndex, CSTaskImp};
+use eldenring::fd4::FD4TaskData;
+use fromsoftware_shared::SharedTaskImpExt;
+
+/// Worker-thread entry, spawned from `DllMain`. Mirrors the C++ `CCore::on_attach` + `Run` loop,
+/// but instead of a 2s sleep loop it registers a per-frame task (the idiomatic fromsoftware-rs
+/// pattern) — strictly better than `RUN_SLEEP=2000` for pickup latency and flag polling.
+/// Crash-forensic breadcrumb: append one line to `<logs>/eldenring-ap_<ts>.trace.log` and fsync it,
+/// so the LAST step before a hard crash is guaranteed on disk (the non-blocking tracing sink can
+/// lose un-flushed lines when `panic = "abort"` tears the process down). Per-launch timestamped name
+/// so it is always a fresh path, readable through the dev mount.
+fn breadcrumb(step: &str) {
+    use std::io::Write;
+    static PATH: std::sync::OnceLock<std::path::PathBuf> = std::sync::OnceLock::new();
+    let path = PATH.get_or_init(|| {
+        let dir = std::env::var("ER_AP_LOG_DIR").ok().unwrap_or_else(|| {
+            let mut p = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+            p.pop();
+            p.pop();
+            p.push("logs");
+            p.to_string_lossy().into_owned()
+        });
+        let _ = std::fs::create_dir_all(&dir);
+        std::path::Path::new(&dir).join(format!("eldenring-ap_{}.trace.log", crate::log_timestamp()))
+    });
+    if let Ok(mut f) = std::fs::OpenOptions::new().create(true).append(true).open(path) {
+        let _ = writeln!(f, "{step}");
+        let _ = f.flush();
+        let _ = f.sync_all();
+    }
+}
+
+pub fn init() {
+    breadcrumb("init: start");
+    let _log_guard = init_logging();
+    breadcrumb("init: logging ready");
+    tracing::info!("eldenring-ap {}: worker thread up", crate::CONTRACT_VERSION);
+
+    // The Phase-1 spike (goods rowCount) runs on the first IN-WORLD tick (see tick()), NOT here:
+    // at PROCESS_ATTACH the SoloParamRepository global is uninitialized, so touching it this early
+    // faults and (panic=abort) crashes the game during boot.
+
+    // DETECT/GRANT: install the AddItemFunc detour (Phase 3; `detour` feature, now default + stable).
+    // BEST-EFFORT: if the pinned RVA is stale for this game build the signature guard refuses to
+    // install — log and CONTINUE so the Phase-1 probe and the rest of init still run.
+    #[cfg(feature = "detour")]
+    if let Err(e) = detour::install() {
+        breadcrumb("init: detour install failed (continuing without it)");
+        tracing::error!("AddItemFunc detour install failed: {e}");
+    }
+
+    // Debug console (ports the C++ client's /setflag, /getflag window). Reads stdin on its own thread;
+    // commands execute on the game tick (console::tick). Behind `detour` (needs the windows crate).
+    #[cfg(feature = "detour")]
+    console::init();
+
+    // The settled in-world tick. Everything that must run on the game thread goes here: draining
+    // the received-items / grant / grace-flag queues, polling location flags (REPORT for
+    // acquisitions that bypass the detour), evaluating natural-key triggers, etc. (SPEC §4 phase 5)
+    breadcrumb("init: before wait_for_instance(CSTaskImp)");
+    let cs_task = match CSTaskImp::wait_for_instance(Duration::MAX) {
+        Ok(t) => {
+            breadcrumb("init: CSTaskImp ready");
+            t
+        }
+        Err(e) => {
+            breadcrumb("init: CSTaskImp ERR (returning)");
+            tracing::error!("no CSTaskImp: {e:?}");
+            return;
+        }
+    };
+    // RESOLVED: run_recurring returns a RecurringTaskHandle that unregisters the per-frame task when
+    // dropped — so it MUST be held for the process lifetime (the sketch previously dropped it).
+    breadcrumb("init: before run_recurring(FrameBegin)");
+    let _task_handle = cs_task.run_recurring(
+        |_: &FD4TaskData| {
+            tick();
+        },
+        CSTaskGroupIndex::FrameBegin,
+    );
+    breadcrumb("init: run_recurring registered; parking worker thread");
+
+    // Phase 4: run the AP networking loop on THIS worker thread (off the game thread): connect,
+    // poll archipelago_rs, drain the report queue -> LocationChecks, push received items onto the
+    // grant queue the FrameBegin tick drains. Running it here (not a fresh thread) keeps the
+    // FrameBegin registration `_task_handle` alive for free — net::run() never returns.
+    #[cfg(feature = "net")]
+    {
+        breadcrumb("init: entering AP net loop (worker thread)");
+        net::run();
+    }
+
+    // Lean detour-only / --no-default-features build: just park the worker thread so `_task_handle`
+    // (the FrameBegin task) stays alive for the process lifetime.
+    #[cfg(not(feature = "net"))]
+    loop {
+        std::thread::sleep(Duration::from_secs(60));
+    }
+}
+
+/// One settled-in-world game tick. No-op until the queues exist (phase 4/5).
+fn tick() {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    // One-shot: lets us tell "crashed before any frame" (task setup) from "crashed in the param
+    // probe" (the spike below).
+    static FIRST_FRAME: AtomicBool = AtomicBool::new(true);
+    if FIRST_FRAME.swap(false, Ordering::Relaxed) {
+        breadcrumb("tick: first frame reached");
+    }
+
+    // Phase-1 proof: log the goods rowCount once we are IN-WORLD. Gating on WorldChrMan.main_player
+    // (not merely "a frame ran") is the fix for the boot-time crash: at the first frames the param
+    // tables aren't populated and iterating EquipParamGoods faults; in-world they are loaded.
+    static SPIKE_DONE: AtomicBool = AtomicBool::new(false);
+    static PROBE_ANNOUNCED: AtomicBool = AtomicBool::new(false);
+    if !SPIKE_DONE.load(Ordering::Relaxed) && flags::in_world() {
+        if !PROBE_ANNOUNCED.swap(true, Ordering::Relaxed) {
+            breadcrumb("tick: in-world; probing SoloParamRepository");
+        }
+        if params::spike_log_goods_rowcount() {
+            breadcrumb("tick: spike resolved (rowCount logged)");
+            SPIKE_DONE.store(true, Ordering::Relaxed);
+        }
+    }
+
+    // Phase 4: drain the received-items queue (filled by the AP net thread) and grant each item
+    // in-game on THIS thread, where touching inventory is safe; persists last_received_index after
+    // each grant. Gated on in-world inside drain_and_grant().
+    // Phase 5: execute any queued debug-console commands (/setflag, /getflag, ...) on the game thread.
+    #[cfg(feature = "detour")]
+    console::tick();
+
+    #[cfg(feature = "net")]
+    grant::drain_and_grant();
+
+    // Phase 4: ending_condition 0/1 GOAL detection — poll the boss defeat flag HERE (event-flag
+    // reads are only safe on the game thread) and tell the net loop to send CLIENT_GOAL once.
+    #[cfg(feature = "net")]
+    {
+        let gf = net::goal_flag();
+        if gf != 0 && flags::get_event_flag(gf) {
+            net::signal_goal();
+        }
+    }
+
+    // Phase 5: the settled-in-world feature tick — flush pending grace/open/reveal flags, grant
+    // queued notify + start items, reveal maps, evaluate natural-key triggers, poll location flags
+    // (detour-bypassing acquisitions -> report queue), and run the warp / region-lock latches. All
+    // event-flag reads/writes + grants happen HERE (game thread); the net thread only queued them.
+    #[cfg(feature = "net")]
+    features::tick();
+
+    // Phase 5 parallel tracks: progressive bells/physick grant+flag drain (Wave C), DeathLink
+    // kill/death latches (Wave D, RE-gated), and the global Scadutree blessing writer (RE-gated).
+    // Each self-gates (off unless its slot_data flag is set / in-world), so all three are cheap no-ops.
+    #[cfg(feature = "net")]
+    progressive::tick();
+    #[cfg(feature = "net")]
+    deathlink::tick();
+    #[cfg(feature = "net")]
+    upgrades::tick_global_scadu();
+}
+
+/// Set up file logging (replaces spdlog with a non-blocking tracing file sink).
+///
+/// Writes `<spike>/logs/eldenring-ap_<YYYYMMDD_HHMMSS>.log`. The dir is derived from
+/// CARGO_MANIFEST_DIR at build time (overridable with $ER_AP_LOG_DIR). A fresh timestamped name per
+/// launch means the file is always a NEW path — readable straight off the (otherwise stale-cached)
+/// dev mount, and it never clobbers a prior run. Returns the `WorkerGuard`, which the caller MUST
+/// keep alive for the process lifetime or the background writer thread shuts down and lines are lost.
+fn init_logging() -> Option<tracing_appender::non_blocking::WorkerGuard> {
+    let dir = std::env::var("ER_AP_LOG_DIR").ok().unwrap_or_else(|| {
+        let mut p = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")); // <spike>\crates\eldenring-ap
+        p.pop(); // <spike>\crates
+        p.pop(); // <spike>
+        p.push("logs");
+        p.to_string_lossy().into_owned()
+    });
+    if std::fs::create_dir_all(&dir).is_err() {
+        // Never panic on the loader thread: fall back to the default (stdout) subscriber.
+        let _ = tracing_subscriber::fmt().with_max_level(tracing::Level::DEBUG).try_init();
+        return None;
+    }
+    let filename = format!("eldenring-ap_{}.log", crate::log_timestamp());
+    let appender = tracing_appender::rolling::never(&dir, &filename);
+    let (writer, guard) = tracing_appender::non_blocking(appender);
+    let _ = tracing_subscriber::fmt()
+        .with_writer(writer)
+        .with_ansi(false)
+        .with_max_level(tracing::Level::DEBUG)
+        .try_init();
+    tracing::info!("log file: {}\\{}", dir, filename);
+    Some(guard)
+}

--- a/crates/eldenring-archipelago/src/game/mod.rs
+++ b/crates/eldenring-archipelago/src/game/mod.rs
@@ -69,9 +69,14 @@ fn breadcrumb(step: &str) {
             p.to_string_lossy().into_owned()
         });
         let _ = std::fs::create_dir_all(&dir);
-        std::path::Path::new(&dir).join(format!("eldenring-ap_{}.trace.log", crate::log_timestamp()))
+        std::path::Path::new(&dir)
+            .join(format!("eldenring-ap_{}.trace.log", crate::log_timestamp()))
     });
-    if let Ok(mut f) = std::fs::OpenOptions::new().create(true).append(true).open(path) {
+    if let Ok(mut f) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+    {
         let _ = writeln!(f, "{step}");
         let _ = f.flush();
         let _ = f.sync_all();
@@ -227,7 +232,9 @@ fn init_logging() -> Option<tracing_appender::non_blocking::WorkerGuard> {
     });
     if std::fs::create_dir_all(&dir).is_err() {
         // Never panic on the loader thread: fall back to the default (stdout) subscriber.
-        let _ = tracing_subscriber::fmt().with_max_level(tracing::Level::DEBUG).try_init();
+        let _ = tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::DEBUG)
+            .try_init();
         return None;
     }
     let filename = format!("eldenring-ap_{}.log", crate::log_timestamp());

--- a/crates/eldenring-archipelago/src/game/net.rs
+++ b/crates/eldenring-archipelago/src/game/net.rs
@@ -1,0 +1,558 @@
+//! Phase 4 — Archipelago networking. Rust port of `ArchipelagoInterface.cpp`'s protocol layer onto
+//! nex3's `archipelago_rs` (the crate fswap's DS3/Sekiro clients use). The crate is POLL-based
+//! (`Connection::update()` returns the events since the last poll), so it needs no async runtime —
+//! it runs on this worker thread (the one `game::init()` parks), strictly off the game thread.
+//!
+//! Scope = SPEC §4 phase 4 MVP (goods-only end-to-end): connect, read the minimal slot_data, push
+//! received items onto the `grant` queue, drain our collected-location queue into `mark_checked`,
+//! and report GOAL (ec 0/1 boss flag via the game tick, ec>=2 via goalLocations). The large slot_data
+//! feature surface (region graces, natural keys, progressive bells, DLC auto-entry, …) is Phase 5
+//! (see PHASE5-PORT-PLAN.md), so we read slot_data out of a `serde_json::Value` field-by-field with
+//! defaults — a malformed/extra/unexpected field can never fail the CONNECTION (a typed slot_data
+//! struct would: e.g. `enable_dlc` ships as an int 0/1, not a JSON bool).
+
+#![allow(dead_code)] // signal_goal()/persisted_index() are wired ahead of their Phase-5 callers
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::time::Duration;
+
+use archipelago_rs as ap;
+use serde::Deserialize;
+
+use super::{deathlink, features, flags, grant, progressive, upgrades};
+
+/// `apconfig.json` (next to the game exe, or $ER_AP_CONFIG). The console-prompt flow the C++ used is
+/// replaced by a config file for the spike (SPEC §6 lists this as an accepted option). This is OUR
+/// file with a fixed shape, so a typed struct is fine here (unlike server slot_data).
+#[derive(Debug, Default, Deserialize)]
+struct ApConfig {
+    /// `host:port`, e.g. "archipelago.gg:38281".
+    url: String,
+    #[serde(default)]
+    slot: Option<String>,
+    #[serde(default)]
+    password: Option<String>,
+    /// AP location id (stringified) -> guarding event flag. Polled each tick to catch checks whose
+    /// acquisition bypasses the AddItemFunc detour (shop buys, NPC gifts, offline pickups). Emitted
+    /// by the ER bake INTO apconfig (NOT slot_data). (`location_flags` in CCore::LoadConfigFile.)
+    #[serde(default)]
+    location_flags: HashMap<String, u32>,
+    /// Boss/grace attribution sweep: event flag (stringified) -> AP location ids it clears.
+    /// Present only when the apworld's dungeon_sweep == bosses. (`sweep_flags`.)
+    #[serde(default)]
+    sweep_flags: HashMap<String, Vec<i64>>,
+    /// DeathLink hint: the `DeathLink` Connect tag must be advertised at CONNECT (before slot_data
+    /// arrives), so it's sourced from apconfig. slot_data `options.death_link` is the source of truth
+    /// once connected and corrects `is_enabled()`; this only makes the tag right on the first connect.
+    #[serde(default)]
+    death_link: bool,
+}
+
+static GOAL_REACHED: AtomicBool = AtomicBool::new(false);
+/// Boss DEFEAT flag for ending_condition 0/1 (0 = none / ec>=2 uses goalLocations). Set at slot_data
+/// parse; the GAME tick polls it (event-flag reads must run on the game thread).
+static GOAL_FLAG: AtomicU32 = AtomicU32::new(0);
+
+/// Phase 5 will call this from the game tick when the slot's ending condition is detected; the net
+/// loop turns it into one `set_status(Goal)`.
+pub fn signal_goal() {
+    GOAL_REACHED.store(true, Ordering::Relaxed);
+}
+
+/// The ending_condition 0/1 boss flag the game tick should poll (0 = none).
+pub fn goal_flag() -> u32 {
+    GOAL_FLAG.load(Ordering::Relaxed)
+}
+
+/// Worker-thread entry. Loads apconfig, then connect-and-serve in a reconnect loop. Never returns
+/// (keeps the FrameBegin task handle in `init()` alive).
+pub fn run() {
+    let cfg = match load_apconfig() {
+        Some(c) if !c.url.is_empty() => c,
+        _ => return, // load_apconfig already logged where it looked
+    };
+    tracing::info!("AP: config loaded; target {}", cfg.url);
+    // DeathLink tag must be known at Connect time (before slot_data); seed it from apconfig. slot_data
+    // corrects it once connected. (See deathlink.rs / DEATHLINK-WIRING.md.)
+    deathlink::set_enabled(cfg.death_link);
+
+    loop {
+        connect_and_serve(&cfg);
+        tracing::warn!("AP: connection closed; reconnecting in 5s");
+        std::thread::sleep(Duration::from_secs(5));
+    }
+}
+
+/// One connection lifecycle: build a `Connection`, poll it, and pump items/checks until it drops.
+fn connect_and_serve(cfg: &ApConfig) {
+    let slot = cfg.slot.clone().unwrap_or_default();
+
+    let mut opts = ap::ConnectionOptions::new().receive_items(ap::ItemHandling::OtherWorlds {
+        own_world: true,        // echo self-found items (shop buys bypass the detour) — C++ 0b111
+        starting_inventory: true,
+    });
+    if let Some(pw) = &cfg.password {
+        if !pw.is_empty() {
+            opts = opts.password(pw.clone());
+        }
+    }
+    // DeathLink (Wave D): tags() REPLACES the set, and the server reads tags only at Connect — so add
+    // it here, before slot_data. `ap::tags::DEATH_LINK` = "DeathLink". (DEATHLINK-WIRING.md §2a.)
+    if deathlink::is_enabled() {
+        opts = opts.tags([ap::tags::DEATH_LINK]);
+    }
+
+    // slot_data read as serde_json::Value (the default S), so no field-type assumption can fail the
+    // connection. &str satisfies Into<String>/Into<Ustr> without relying on &String coercions.
+    let mut conn: ap::Connection<serde_json::Value> =
+        ap::Connection::new(cfg.url.as_str(), slot.as_str(), Some("EldenRing"), opts);
+
+    let mut configured = false;
+    let mut pushed_through: i64 = 0; // highest received index already pushed to the GRANT queue
+    let mut dispatched_through: i64 = 0; // highest index whose NAME-dispatch (flags/sets) has run.
+    // Starts at 0 EACH connect (not the persisted index): the name-keyed effects (grace flags,
+    // received-name set for natural keys) are idempotent and must replay the FULL items_received
+    // stream on reconnect, unlike the grant path which resumes at the persisted index.
+    let mut goal_sent = false;
+    let mut item_map: HashMap<i64, i64> = HashMap::new(); // AP item id -> ER FullID
+    let mut item_counts: HashMap<i64, i64> = HashMap::new();
+    let mut goal_locations: Vec<i64> = Vec::new();
+    let mut goal_via_locations = false;
+
+    loop {
+        // 1) Drain server events (owned Vec, so the &mut borrow on conn ends here).
+        for ev in conn.update() {
+            match ev {
+                ap::Event::Connected => tracing::info!("AP: connected to {} as {}", cfg.url, slot),
+                ap::Event::ReceivedItems(first) => {
+                    tracing::debug!("AP: ReceivedItems from index {first}")
+                }
+                ap::Event::Print(p) => tracing::info!("AP: {}", p),
+                ap::Event::Error(e) => {
+                    tracing::error!("AP: connection error: {e}");
+                    return;
+                }
+                ap::Event::DeathLink { source, cause, .. } => {
+                    // Wave D: latch a kill for the game tick (deathlink::tick); self-source echoes are
+                    // suppressed inside the handler. (DEATHLINK-WIRING.md §2c.)
+                    deathlink::on_death_link_event(&source, cause.as_deref(), slot.as_str());
+                }
+                _ => {}
+            }
+        }
+
+        // 2) On first sight of the connected client, read slot_data (field-by-field, all optional).
+        if !configured {
+            if let Some(client) = conn.client() {
+                let sd = client.slot_data(); // &serde_json::Value
+                item_map = i64_map(sd.get("apIdsToItemIds"));
+                item_counts = i64_map(sd.get("itemCounts"));
+
+                if let Some(range) = sd.get("versions").and_then(|v| v.as_str()) {
+                    if !crate::contract_satisfies(range) {
+                        tracing::warn!(
+                            "AP: contract {} not in server range {} — update one side",
+                            crate::CONTRACT_VERSION,
+                            range
+                        );
+                    }
+                }
+
+                let seed = sd.get("seed").and_then(|v| v.as_str()).unwrap_or("");
+                let sd_slot = sd.get("slot").and_then(|v| v.as_str()).unwrap_or("");
+                let slot_name = if sd_slot.is_empty() { slot.as_str() } else { sd_slot };
+                let save_path = save_path_for(seed, slot_name);
+                let start_index = load_last_index(&save_path);
+                grant::configure(save_path, start_index);
+                pushed_through = start_index;
+
+                // Goal config (ec 0/1 boss flag vs ec>=2 goalLocations). enable_dlc ships as int 0/1.
+                let ec = sd.pointer("/options/ending_condition").and_then(|v| v.as_i64()).unwrap_or(1);
+                let dlc = sd
+                    .pointer("/options/enable_dlc")
+                    .map(|v| v.as_bool().unwrap_or_else(|| v.as_i64().unwrap_or(0) != 0))
+                    .unwrap_or(false);
+                if ec >= 2 {
+                    goal_locations = sd
+                        .get("goalLocations")
+                        .and_then(|v| v.as_array())
+                        .map(|a| a.iter().filter_map(|x| x.as_i64()).collect())
+                        .unwrap_or_default();
+                    goal_via_locations = !goal_locations.is_empty();
+                    GOAL_FLAG.store(0, Ordering::Relaxed);
+                    tracing::info!("AP: goal = all {} goal location(s) checked (ec {})", goal_locations.len(), ec);
+                } else {
+                    let flag: u32 = if ec == 0 && dlc { 20_012_802 } else { 19_000_800 };
+                    GOAL_FLAG.store(flag, Ordering::Relaxed);
+                    tracing::info!("AP: goal = boss defeat flag {} (ec {}, dlc {})", flag, ec, dlc);
+                }
+
+                // Phase 5: build the feature config (region-lock ecosystem, warp latches, map
+                // reveal, sweeps) from slot_data + apconfig and install it. configure() RESETS the
+                // per-session queues, so start graces/items are enqueued AFTER it.
+                let feat = build_slot_config(sd, dlc, cfg);
+                features::configure(feat);
+
+                // Phase 5 parallel tracks, configured off the same slot_data:
+                progressive::configure(progressive::parse(sd)); // Wave C tier tables
+                deathlink::configure_from_slot_data(sd); // Wave D: corrects is_enabled() from options.death_link
+                upgrades::set_auto_upgrade(
+                    sd.pointer("/options/auto_upgrade").and_then(|v| v.as_i64()).unwrap_or(0) as i32,
+                );
+                upgrades::set_global_scadu_blessing(
+                    sd.pointer("/options/global_scadutree_blessing").and_then(|v| v.as_i64()).unwrap_or(0) as i32,
+                );
+                if let Some(arr) = sd.get("startGraces").and_then(|v| v.as_array()) {
+                    let mut n = 0;
+                    for f in arr {
+                        if let Some(fl) = f.as_u64() {
+                            features::enqueue_start_grace(fl as u32);
+                            n += 1;
+                        }
+                    }
+                    if n > 0 {
+                        tracing::info!("AP: queued {} Limgrave start grace(s)", n);
+                    }
+                }
+                if let Some(arr) = sd.get("startItems").and_then(|v| v.as_array()) {
+                    let mut n = 0;
+                    for e in arr {
+                        if let Some(pair) = e.as_array() {
+                            let id = pair.first().and_then(|x| x.as_i64()).unwrap_or(0) as i32;
+                            let ct = pair.get(1).and_then(|x| x.as_i64()).unwrap_or(1) as i32;
+                            if id != 0 {
+                                features::enqueue_start_item(id, ct);
+                                n += 1;
+                            }
+                        } else if let Some(id) = e.as_i64() {
+                            features::enqueue_start_item(id as i32, 1);
+                            n += 1;
+                        }
+                    }
+                    if n > 0 {
+                        tracing::info!("AP: queued {} once-per-save start item(s)", n);
+                    }
+                }
+                dispatched_through = 0; // replay name-dispatch from the start on this connect
+
+                tracing::info!(
+                    "AP: slot_data parsed ({} item-map entries); resuming at received index {}",
+                    item_map.len(),
+                    start_index
+                );
+                configured = true;
+            }
+        }
+
+        // 3) Process received items. NAME-dispatch (idempotent grace flags / region-lock effects /
+        // received-name set) runs over the FULL replay each connect (idx >= dispatched_through);
+        // the GRANT enqueue resumes at the persisted index (idx >= pushed_through) to avoid
+        // re-granting. Both watermarks advance independently. (set_items_received_handler split.)
+        if configured {
+            if let Some(client) = conn.client() {
+                for ri in client.received_items() {
+                    let idx = ri.index() as i64;
+                    let name = ri.item().name().to_string();
+                    let mut is_progressive = false;
+
+                    if idx >= dispatched_through {
+                        features::on_item_received(&name);
+                        // Progressive (Wave C): advances its own tier (persisted index-deduped) and
+                        // returns true for progressive items, which carry their OWN grant queue —
+                        // so the normal grant below is SKIPPED (mirrors the C++ handler's `continue`).
+                        is_progressive = progressive::on_item_received(&name, idx);
+                        dispatched_through = idx + 1;
+                    }
+
+                    if idx >= pushed_through {
+                        if !is_progressive {
+                            let ap_item_id = ri.item().id();
+                            match item_map.get(&ap_item_id) {
+                                Some(&full_id) => {
+                                    let qty = item_counts.get(&ap_item_id).copied().unwrap_or(1).max(1);
+                                    grant::enqueue(grant::GrantMsg {
+                                        full_id: full_id as i32,
+                                        qty: qty as i32,
+                                        ap_index: idx,
+                                        name,
+                                    });
+                                }
+                                None => tracing::warn!(
+                                    "AP: received item id {} not in apIdsToItemIds; skipping (check seed options)",
+                                    ap_item_id
+                                ),
+                            }
+                        }
+                        pushed_through = idx + 1;
+                    }
+                }
+            }
+        }
+
+        // 4) Send our collected locations (filled by the AddItemFunc detour via flags::report_location).
+        let checks = flags::drain_reported();
+        if !checks.is_empty() {
+            if let Some(client) = conn.client_mut() {
+                let n = checks.len();
+                if let Err(e) = client.mark_checked(checks) {
+                    tracing::warn!("AP: mark_checked failed ({e}); {n} check(s) dropped");
+                } else {
+                    tracing::debug!("AP: sent {n} location check(s)");
+                }
+            } else {
+                for c in checks {
+                    flags::report_location(c); // re-queue; not connected yet
+                }
+            }
+        }
+
+        // 5a) ending_condition 2/3 goal: all goalLocations checked (server-truth, retroactive on
+        // reconnect). ec 0/1 boss-flag goals are detected on the game tick, which calls signal_goal().
+        if goal_via_locations && !goal_sent {
+            if let Some(client) = conn.client() {
+                if goal_locations.iter().all(|&g| client.is_local_location_checked(g)) {
+                    signal_goal();
+                }
+            }
+        }
+
+        // 5b) Send CLIENT_GOAL once GOAL_REACHED is set (by 5a or the game tick's flag poll).
+        if !goal_sent && GOAL_REACHED.load(Ordering::Relaxed) {
+            if let Some(client) = conn.client_mut() {
+                if client.set_status(ap::ClientStatus::Goal).is_ok() {
+                    tracing::info!("AP: sent GOAL");
+                    goal_sent = true;
+                }
+            }
+        }
+
+        // 6) Wave D: if the local player died this session, originate a DeathLink (rising-edge latched
+        // on the game tick by deathlink::poll_outgoing_death). (DEATHLINK-WIRING.md §2d.)
+        if deathlink::take_pending_outgoing() {
+            if let Some(client) = conn.client_mut() {
+                let opts = ap::DeathLinkOptions::new()
+                    .cause("Slain in the Lands Between.".to_string())
+                    .source(slot.clone());
+                match client.death_link(opts) {
+                    Ok(()) => tracing::info!("AP: sent DeathLink"),
+                    Err(e) => tracing::warn!("AP: death_link send failed: {e}"),
+                }
+            } else {
+                tracing::debug!("AP: DeathLink to send but client not ready; dropping");
+            }
+        }
+
+        if conn.is_disconnected() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+/// Build an `i64 -> i64` map from a slot_data JSON object whose keys are stringified ints (the AP
+/// convention for `apIdsToItemIds` / `itemCounts`). Tolerant: skips any entry that doesn't parse.
+fn i64_map(v: Option<&serde_json::Value>) -> HashMap<i64, i64> {
+    let mut m = HashMap::new();
+    if let Some(serde_json::Value::Object(o)) = v {
+        for (k, val) in o {
+            if let (Ok(ki), Some(vi)) = (k.parse::<i64>(), val.as_i64()) {
+                m.insert(ki, vi);
+            }
+        }
+    }
+    m
+}
+
+/// Build the Phase-5 feature config from slot_data (`sd`) + apconfig (`apcfg`). Every field is
+/// optional/tolerant so an older seed that omits a key leaves that feature inert. Mirrors the
+/// slot_data parse spread across `set_data_package_handler` / `set_slot_connected_handler` and the
+/// apconfig `location_flags` / `sweep_flags` load in `CCore::LoadConfigFile`.
+fn build_slot_config(sd: &serde_json::Value, dlc: bool, apcfg: &ApConfig) -> features::SlotConfig {
+    let mut c = features::SlotConfig {
+        enable_dlc: dlc,
+        ..Default::default()
+    };
+
+    c.region_graces = str_to_u32vec(sd.get("regionGraces"));
+    c.grace_items = str_to_u32(sd.get("graceItems"));
+    c.region_open_flags = str_to_u32(sd.get("regionOpenFlags"));
+    c.lock_reveal_flags = str_to_u32vec(sd.get("lockRevealFlags"));
+    c.lock_notify_items = str_to_i32(sd.get("lockNotifyItems"));
+    c.natural_key_triggers = parse_natural_keys(sd.get("naturalKeyTriggers"));
+
+    c.dlc_entry_warp_flag = sd.get("dlcEntryWarpFlag").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
+    c.dlc_start_area_id = sd.get("dlcStartAreaId").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
+    c.random_start_warp_flag = sd.get("randomStartWarpFlag").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
+    c.random_start_area_id = sd.get("randomStartAreaId").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
+    c.random_start_done_flag = sd.get("randomStartDoneFlag").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
+
+    c.area_lock_flags = sd
+        .get("areaLockFlags")
+        .and_then(|v| v.as_array())
+        .map(|outer| {
+            outer
+                .iter()
+                .filter_map(|row| row.as_array())
+                .filter(|r| r.len() >= 3)
+                .map(|r| {
+                    [
+                        r[0].as_i64().unwrap_or(0) as i32,
+                        r[1].as_i64().unwrap_or(0) as i32,
+                        r[2].as_i64().unwrap_or(0) as i32,
+                    ]
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    c.reveal_all_maps = sd.get("reveal_all_maps").and_then(|v| v.as_bool()).unwrap_or(false);
+
+    // dungeonSweeps: { "<trigger location id>": [members...] } (slot_data).
+    if let Some(serde_json::Value::Object(o)) = sd.get("dungeonSweeps") {
+        for (k, v) in o {
+            if let (Ok(ki), Some(arr)) = (k.parse::<i64>(), v.as_array()) {
+                c.dungeon_sweeps
+                    .insert(ki, arr.iter().filter_map(|x| x.as_i64()).collect());
+            }
+        }
+    }
+
+    // apconfig-side maps (keys are stringified ints in the JSON object).
+    for (k, &flag) in &apcfg.location_flags {
+        if let Ok(loc) = k.parse::<i64>() {
+            c.location_flags.insert(loc, flag);
+        }
+    }
+    for (k, locs) in &apcfg.sweep_flags {
+        if let Ok(flag) = k.parse::<u32>() {
+            c.sweep_flags.insert(flag, locs.clone());
+        }
+    }
+
+    c
+}
+
+/// `{ "name": <u32> }` slot_data object -> name->flag map. Tolerant: skips non-numeric values.
+fn str_to_u32(v: Option<&serde_json::Value>) -> HashMap<String, u32> {
+    let mut m = HashMap::new();
+    if let Some(serde_json::Value::Object(o)) = v {
+        for (k, val) in o {
+            if let Some(n) = val.as_u64() {
+                m.insert(k.clone(), n as u32);
+            }
+        }
+    }
+    m
+}
+
+/// `{ "name": <i32> }` slot_data object -> name->FullID map (signed; FullIDs carry the category nibble).
+fn str_to_i32(v: Option<&serde_json::Value>) -> HashMap<String, i32> {
+    let mut m = HashMap::new();
+    if let Some(serde_json::Value::Object(o)) = v {
+        for (k, val) in o {
+            if let Some(n) = val.as_i64() {
+                m.insert(k.clone(), n as i32);
+            }
+        }
+    }
+    m
+}
+
+/// `{ "name": [<u32>, ...] }` slot_data object -> name->flags map.
+fn str_to_u32vec(v: Option<&serde_json::Value>) -> HashMap<String, Vec<u32>> {
+    let mut m = HashMap::new();
+    if let Some(serde_json::Value::Object(o)) = v {
+        for (k, val) in o {
+            if let Some(arr) = val.as_array() {
+                m.insert(k.clone(), arr.iter().filter_map(|x| x.as_u64().map(|n| n as u32)).collect());
+            }
+        }
+    }
+    m
+}
+
+/// `{ "LockName": { "anyOf": [ {"items":[..],"flags":[..]}, ... ] } }` -> region->clause disjunction.
+fn parse_natural_keys(v: Option<&serde_json::Value>) -> HashMap<String, Vec<features::NkClause>> {
+    let mut m = HashMap::new();
+    if let Some(serde_json::Value::Object(o)) = v {
+        for (region, body) in o {
+            let mut clauses = Vec::new();
+            if let Some(any_of) = body.get("anyOf").and_then(|x| x.as_array()) {
+                for c in any_of {
+                    let items = c
+                        .get("items")
+                        .and_then(|x| x.as_array())
+                        .map(|a| a.iter().filter_map(|s| s.as_str().map(String::from)).collect())
+                        .unwrap_or_default();
+                    let flags = c
+                        .get("flags")
+                        .and_then(|x| x.as_array())
+                        .map(|a| a.iter().filter_map(|s| s.as_u64().map(|n| n as u32)).collect())
+                        .unwrap_or_default();
+                    clauses.push(features::NkClause { items, flags });
+                }
+            }
+            m.insert(region.clone(), clauses);
+        }
+    }
+    m
+}
+
+/// Find apconfig.json: $ER_AP_CONFIG, then next to the game exe (`<Game>\apconfig.json`), then CWD.
+/// Logs every path tried so it's obvious where to drop the file.
+fn load_apconfig() -> Option<ApConfig> {
+    let mut candidates: Vec<PathBuf> = Vec::new();
+    if let Ok(p) = std::env::var("ER_AP_CONFIG") {
+        candidates.push(PathBuf::from(p));
+    }
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(dir) = exe.parent() {
+            candidates.push(dir.join("apconfig.json")); // <Game>\apconfig.json (ME2 / next to exe)
+            candidates.push(dir.join("mods").join("apconfig.json")); // <Game>\mods\apconfig.json (EML, next to the DLL)
+        }
+    }
+    candidates.push(PathBuf::from("apconfig.json")); // CWD fallback
+
+    for path in &candidates {
+        match std::fs::read_to_string(path) {
+            Ok(text) => match serde_json::from_str::<ApConfig>(&text) {
+                Ok(c) => {
+                    tracing::info!("AP: loaded config from {}", path.display());
+                    return Some(c);
+                }
+                Err(e) => tracing::error!("AP: found {} but failed to parse it: {e}", path.display()),
+            },
+            Err(_) => tracing::debug!("AP: no config at {}", path.display()),
+        }
+    }
+    tracing::error!(
+        "AP: no usable apconfig.json (looked at: {}). Create one next to the game exe: \
+         {{\"url\":\"host:port\",\"slot\":\"Name\"}}. Networking disabled.",
+        candidates.iter().map(|p| p.display().to_string()).collect::<Vec<_>>().join(", ")
+    );
+    None
+}
+
+/// `archipelago/<seed>_<slot>.json` relative to CWD (mirrors CCore::InitSavePath). Filename parts are
+/// sanitised so an exotic seed/slot can't escape the directory.
+fn save_path_for(seed: &str, slot: &str) -> PathBuf {
+    let _ = std::fs::create_dir_all("archipelago");
+    let safe = |s: &str| -> String {
+        s.chars()
+            .map(|c| if c.is_ascii_alphanumeric() || c == '-' || c == '_' { c } else { '_' })
+            .collect()
+    };
+    PathBuf::from("archipelago").join(format!("{}_{}.json", safe(seed), safe(slot)))
+}
+
+fn load_last_index(path: &PathBuf) -> i64 {
+    match std::fs::read_to_string(path) {
+        Ok(t) => serde_json::from_str::<serde_json::Value>(&t)
+            .ok()
+            .and_then(|v| v.get("last_received_index").and_then(|x| x.as_i64()))
+            .unwrap_or(0),
+        Err(_) => 0,
+    }
+}

--- a/crates/eldenring-archipelago/src/game/net.rs
+++ b/crates/eldenring-archipelago/src/game/net.rs
@@ -90,7 +90,7 @@ fn connect_and_serve(cfg: &ApConfig) {
     let slot = cfg.slot.clone().unwrap_or_default();
 
     let mut opts = ap::ConnectionOptions::new().receive_items(ap::ItemHandling::OtherWorlds {
-        own_world: true,        // echo self-found items (shop buys bypass the detour) — C++ 0b111
+        own_world: true, // echo self-found items (shop buys bypass the detour) — C++ 0b111
         starting_inventory: true,
     });
     if let Some(pw) = &cfg.password {
@@ -112,9 +112,9 @@ fn connect_and_serve(cfg: &ApConfig) {
     let mut configured = false;
     let mut pushed_through: i64 = 0; // highest received index already pushed to the GRANT queue
     let mut dispatched_through: i64 = 0; // highest index whose NAME-dispatch (flags/sets) has run.
-    // Starts at 0 EACH connect (not the persisted index): the name-keyed effects (grace flags,
-    // received-name set for natural keys) are idempotent and must replay the FULL items_received
-    // stream on reconnect, unlike the grant path which resumes at the persisted index.
+                                         // Starts at 0 EACH connect (not the persisted index): the name-keyed effects (grace flags,
+                                         // received-name set for natural keys) are idempotent and must replay the FULL items_received
+                                         // stream on reconnect, unlike the grant path which resumes at the persisted index.
     let mut goal_sent = false;
     let mut item_map: HashMap<i64, i64> = HashMap::new(); // AP item id -> ER FullID
     let mut item_counts: HashMap<i64, i64> = HashMap::new();
@@ -162,14 +162,21 @@ fn connect_and_serve(cfg: &ApConfig) {
 
                 let seed = sd.get("seed").and_then(|v| v.as_str()).unwrap_or("");
                 let sd_slot = sd.get("slot").and_then(|v| v.as_str()).unwrap_or("");
-                let slot_name = if sd_slot.is_empty() { slot.as_str() } else { sd_slot };
+                let slot_name = if sd_slot.is_empty() {
+                    slot.as_str()
+                } else {
+                    sd_slot
+                };
                 let save_path = save_path_for(seed, slot_name);
                 let start_index = load_last_index(&save_path);
                 grant::configure(save_path, start_index);
                 pushed_through = start_index;
 
                 // Goal config (ec 0/1 boss flag vs ec>=2 goalLocations). enable_dlc ships as int 0/1.
-                let ec = sd.pointer("/options/ending_condition").and_then(|v| v.as_i64()).unwrap_or(1);
+                let ec = sd
+                    .pointer("/options/ending_condition")
+                    .and_then(|v| v.as_i64())
+                    .unwrap_or(1);
                 let dlc = sd
                     .pointer("/options/enable_dlc")
                     .map(|v| v.as_bool().unwrap_or_else(|| v.as_i64().unwrap_or(0) != 0))
@@ -182,11 +189,24 @@ fn connect_and_serve(cfg: &ApConfig) {
                         .unwrap_or_default();
                     goal_via_locations = !goal_locations.is_empty();
                     GOAL_FLAG.store(0, Ordering::Relaxed);
-                    tracing::info!("AP: goal = all {} goal location(s) checked (ec {})", goal_locations.len(), ec);
+                    tracing::info!(
+                        "AP: goal = all {} goal location(s) checked (ec {})",
+                        goal_locations.len(),
+                        ec
+                    );
                 } else {
-                    let flag: u32 = if ec == 0 && dlc { 20_012_802 } else { 19_000_800 };
+                    let flag: u32 = if ec == 0 && dlc {
+                        20_012_802
+                    } else {
+                        19_000_800
+                    };
                     GOAL_FLAG.store(flag, Ordering::Relaxed);
-                    tracing::info!("AP: goal = boss defeat flag {} (ec {}, dlc {})", flag, ec, dlc);
+                    tracing::info!(
+                        "AP: goal = boss defeat flag {} (ec {}, dlc {})",
+                        flag,
+                        ec,
+                        dlc
+                    );
                 }
 
                 // Phase 5: build the feature config (region-lock ecosystem, warp latches, map
@@ -199,10 +219,14 @@ fn connect_and_serve(cfg: &ApConfig) {
                 progressive::configure(progressive::parse(sd)); // Wave C tier tables
                 deathlink::configure_from_slot_data(sd); // Wave D: corrects is_enabled() from options.death_link
                 upgrades::set_auto_upgrade(
-                    sd.pointer("/options/auto_upgrade").and_then(|v| v.as_i64()).unwrap_or(0) as i32,
+                    sd.pointer("/options/auto_upgrade")
+                        .and_then(|v| v.as_i64())
+                        .unwrap_or(0) as i32,
                 );
                 upgrades::set_global_scadu_blessing(
-                    sd.pointer("/options/global_scadutree_blessing").and_then(|v| v.as_i64()).unwrap_or(0) as i32,
+                    sd.pointer("/options/global_scadutree_blessing")
+                        .and_then(|v| v.as_i64())
+                        .unwrap_or(0) as i32,
                 );
                 if let Some(arr) = sd.get("startGraces").and_then(|v| v.as_array()) {
                     let mut n = 0;
@@ -312,7 +336,10 @@ fn connect_and_serve(cfg: &ApConfig) {
         // reconnect). ec 0/1 boss-flag goals are detected on the game tick, which calls signal_goal().
         if goal_via_locations && !goal_sent {
             if let Some(client) = conn.client() {
-                if goal_locations.iter().all(|&g| client.is_local_location_checked(g)) {
+                if goal_locations
+                    .iter()
+                    .all(|&g| client.is_local_location_checked(g))
+                {
                     signal_goal();
                 }
             }
@@ -382,11 +409,26 @@ fn build_slot_config(sd: &serde_json::Value, dlc: bool, apcfg: &ApConfig) -> fea
     c.lock_notify_items = str_to_i32(sd.get("lockNotifyItems"));
     c.natural_key_triggers = parse_natural_keys(sd.get("naturalKeyTriggers"));
 
-    c.dlc_entry_warp_flag = sd.get("dlcEntryWarpFlag").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
-    c.dlc_start_area_id = sd.get("dlcStartAreaId").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
-    c.random_start_warp_flag = sd.get("randomStartWarpFlag").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
-    c.random_start_area_id = sd.get("randomStartAreaId").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
-    c.random_start_done_flag = sd.get("randomStartDoneFlag").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
+    c.dlc_entry_warp_flag = sd
+        .get("dlcEntryWarpFlag")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0) as u32;
+    c.dlc_start_area_id = sd
+        .get("dlcStartAreaId")
+        .and_then(|v| v.as_i64())
+        .unwrap_or(0) as i32;
+    c.random_start_warp_flag = sd
+        .get("randomStartWarpFlag")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0) as u32;
+    c.random_start_area_id = sd
+        .get("randomStartAreaId")
+        .and_then(|v| v.as_i64())
+        .unwrap_or(0) as i32;
+    c.random_start_done_flag = sd
+        .get("randomStartDoneFlag")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0) as u32;
 
     c.area_lock_flags = sd
         .get("areaLockFlags")
@@ -407,7 +449,10 @@ fn build_slot_config(sd: &serde_json::Value, dlc: bool, apcfg: &ApConfig) -> fea
         })
         .unwrap_or_default();
 
-    c.reveal_all_maps = sd.get("reveal_all_maps").and_then(|v| v.as_bool()).unwrap_or(false);
+    c.reveal_all_maps = sd
+        .get("reveal_all_maps")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
 
     // dungeonSweeps: { "<trigger location id>": [members...] } (slot_data).
     if let Some(serde_json::Value::Object(o)) = sd.get("dungeonSweeps") {
@@ -466,7 +511,12 @@ fn str_to_u32vec(v: Option<&serde_json::Value>) -> HashMap<String, Vec<u32>> {
     if let Some(serde_json::Value::Object(o)) = v {
         for (k, val) in o {
             if let Some(arr) = val.as_array() {
-                m.insert(k.clone(), arr.iter().filter_map(|x| x.as_u64().map(|n| n as u32)).collect());
+                m.insert(
+                    k.clone(),
+                    arr.iter()
+                        .filter_map(|x| x.as_u64().map(|n| n as u32))
+                        .collect(),
+                );
             }
         }
     }
@@ -484,12 +534,20 @@ fn parse_natural_keys(v: Option<&serde_json::Value>) -> HashMap<String, Vec<feat
                     let items = c
                         .get("items")
                         .and_then(|x| x.as_array())
-                        .map(|a| a.iter().filter_map(|s| s.as_str().map(String::from)).collect())
+                        .map(|a| {
+                            a.iter()
+                                .filter_map(|s| s.as_str().map(String::from))
+                                .collect()
+                        })
                         .unwrap_or_default();
                     let flags = c
                         .get("flags")
                         .and_then(|x| x.as_array())
-                        .map(|a| a.iter().filter_map(|s| s.as_u64().map(|n| n as u32)).collect())
+                        .map(|a| {
+                            a.iter()
+                                .filter_map(|s| s.as_u64().map(|n| n as u32))
+                                .collect()
+                        })
                         .unwrap_or_default();
                     clauses.push(features::NkClause { items, flags });
                 }
@@ -522,7 +580,9 @@ fn load_apconfig() -> Option<ApConfig> {
                     tracing::info!("AP: loaded config from {}", path.display());
                     return Some(c);
                 }
-                Err(e) => tracing::error!("AP: found {} but failed to parse it: {e}", path.display()),
+                Err(e) => {
+                    tracing::error!("AP: found {} but failed to parse it: {e}", path.display())
+                }
             },
             Err(_) => tracing::debug!("AP: no config at {}", path.display()),
         }
@@ -530,7 +590,11 @@ fn load_apconfig() -> Option<ApConfig> {
     tracing::error!(
         "AP: no usable apconfig.json (looked at: {}). Create one next to the game exe: \
          {{\"url\":\"host:port\",\"slot\":\"Name\"}}. Networking disabled.",
-        candidates.iter().map(|p| p.display().to_string()).collect::<Vec<_>>().join(", ")
+        candidates
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect::<Vec<_>>()
+            .join(", ")
     );
     None
 }
@@ -541,7 +605,13 @@ fn save_path_for(seed: &str, slot: &str) -> PathBuf {
     let _ = std::fs::create_dir_all("archipelago");
     let safe = |s: &str| -> String {
         s.chars()
-            .map(|c| if c.is_ascii_alphanumeric() || c == '-' || c == '_' { c } else { '_' })
+            .map(|c| {
+                if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                    c
+                } else {
+                    '_'
+                }
+            })
             .collect()
     };
     PathBuf::from("archipelago").join(format!("{}_{}.json", safe(seed), safe(slot)))

--- a/crates/eldenring-archipelago/src/game/params.rs
+++ b/crates/eldenring-archipelago/src/game/params.rs
@@ -1,0 +1,92 @@
+//! DECODE layer — resolve a synthetic placeholder's `EquipParamGoods` row and turn it into the
+//! pure [`er_codec::GoodsRowFields`].
+//!
+//! This is the single biggest "delete the binding layer" win. The C++ client hand-walked
+//! `repo -> +idx*0x48+0x88 -> +0x80 -> +0x80 -> rowCount @ +0x0A -> 24-byte index entries -> row`
+//! (er_hooks.h / er_gamehook.h) and then read raw byte offsets (er_goods_row.h). All of that is
+//! replaced by the `eldenring` crate's typed `EQUIP_PARAM_GOODS_ST` + the `ParamDef` "safe param
+//! lookup" trait. We read named fields off a typed struct; the row stride / offsets / blob walk are
+//! the crate's problem (and patch-tracked upstream).
+//!
+//! ⚠️ COMPILE-TARGET SKETCH (not yet built). Lookup symbols RESOLVED against eldenring 0.14
+//! — see the spike root's VERIFY-RESOLUTION.md. This is the Phase-1 spike payoff.
+
+use er_codec::GoodsRowFields;
+
+// RESOLVED (eldenring 0.14.0; see the spike root's VERIFY-RESOLUTION.md): the row STRUCT is
+// `eldenring::param::EQUIP_PARAM_GOODS_ST`, but the turbofish marker for a typed lookup is the
+// zero-sized `eldenring::cs::EquipParamGoods` (impl SoloParam, INDEX 3, StructType =
+// EQUIP_PARAM_GOODS_ST). `ParamDef` is NOT a lookup API — it only carries { NAME, INDEX }. Rows
+// come off the `SoloParamRepository` FD4 singleton via `get` / `rows`.
+use eldenring::cs::{EquipParamGoods, SoloParamRepository};
+use eldenring::param::EQUIP_PARAM_GOODS_ST;
+use fromsoftware_shared::FromStatic;
+
+/// Phase-1 spike: confirm the crate reaches the goods param, and split the count by vanilla vs
+/// synthetic — our injected AP placeholders ARE EquipParamGoods rows with id > SYNTHETIC_GOODS_MIN_ID
+/// (Decision D), so this confirms the ~3795-vs-3571 delta is our own rows. Iterates the table ONCE.
+///
+/// Returns `true` once it has logged a real count (repo reachable), `false` if the param repo isn't
+/// up yet so the caller can retry on a later tick. MUST be called in-world (from tick()), NOT at
+/// PROCESS_ATTACH: the SoloParamRepository global is uninitialized during boot, so touching it that
+/// early faults and (with panic=abort) crashes the game.
+pub fn spike_log_goods_rowcount() -> bool {
+    // SAFETY: FD4 singleton accessor (FromStatic). Returns Err until SoloParamRepository is built.
+    // Caller gates on in-world so the tables are populated. Breadcrumbs localize any residual fault.
+    super::breadcrumb("  param: before SoloParamRepository::instance()");
+    let repo = match unsafe { SoloParamRepository::instance() } {
+        Ok(r) => r,
+        Err(_) => return false,
+    };
+    super::breadcrumb("  param: instance() Ok; before rows() iterate");
+
+    let mut total = 0usize;
+    let mut synthetic = 0usize;
+    let mut first_id = None;
+    for (id, _row) in repo.rows::<EquipParamGoods>() {
+        if first_id.is_none() {
+            first_id = Some(id);
+        }
+        total += 1;
+        // is_synthetic_goods wants a full gib id (category | row); these are goods rows already.
+        if er_codec::is_synthetic_goods(er_codec::CATEGORY_GOODS | id) {
+            synthetic += 1;
+        }
+    }
+    super::breadcrumb("  param: rows() iterate Ok");
+
+    tracing::info!(
+        "EquipParamGoods rowCount = {total} (vanilla {} + synthetic {synthetic} AP placeholders, id>{}), firstRowId = {:?}",
+        total - synthetic,
+        er_codec::SYNTHETIC_GOODS_MIN_ID,
+        first_id
+    );
+    true
+}
+
+/// Look up a goods row by its (category-stripped) row id and project the carrier fields into the
+/// pure decode struct. `None` if the param repo isn't ready or the id is absent.
+///
+/// The five fields are the locked decode contract (er_item_decode.h): the two vagrant halves carry
+/// the AP location id, `basicPrice`/`sellValue` the local replacement, `disableUseAtOutOfColiseum`
+/// bit the foreign-remove flag.
+pub fn goods_row_fields(row_id: i32) -> Option<GoodsRowFields> {
+    // SAFETY: FD4 singleton; on the game thread. `get::<EquipParamGoods>(id: u32)` returns
+    // `Option<&EQUIP_PARAM_GOODS_ST>` (None if the id is absent) — the typed lookup that replaces
+    // the entire manual ParamBase walk.
+    let repo = unsafe { SoloParamRepository::instance() }.ok()?;
+    let row: &EQUIP_PARAM_GOODS_ST = repo.get::<EquipParamGoods>(row_id as u32)?;
+    Some(GoodsRowFields {
+        // RESOLVED: snake_case getter METHODS on EQUIP_PARAM_GOODS_ST (not public fields); the
+        // disableUseAtOutOfColiseum bitfield is exposed as a typed bool getter.
+        vagrant_item_lot_id: row.vagrant_item_lot_id(),
+        vagrant_bonus_ene_drop_item_lot_id: row.vagrant_bonus_ene_drop_item_lot_id(),
+        basic_price: row.basic_price(),
+        sell_value: row.sell_value(),
+        disable_use_at_out_of_coliseum: row.disable_use_at_out_of_coliseum(),
+    })
+}
+
+// Fallback path (only if the crate does NOT expose the goods rows): keep er_codec's raw byte reader
+// (`er_codec::read_goods_row`) over a `*const u8` row pointer obtained from a manual ParamBase walk
+// resolved by AOB. That's the er_hooks.h behavior, ported. Prefer the typed path above.

--- a/crates/eldenring-archipelago/src/game/progressive.rs
+++ b/crates/eldenring-archipelago/src/game/progressive.rs
@@ -319,7 +319,10 @@ pub fn snapshot() -> (serde_json::Value, i64) {
         .iter()
         .map(|(k, &v)| (k.clone(), serde_json::Value::from(v)))
         .collect();
-    (serde_json::Value::Object(map), HIGH_INDEX.load(Ordering::Relaxed))
+    (
+        serde_json::Value::Object(map),
+        HIGH_INDEX.load(Ordering::Relaxed),
+    )
 }
 
 /// Restore the persisted state from the per-seed save at (re)connect — called BY grant.rs's

--- a/crates/eldenring-archipelago/src/game/progressive.rs
+++ b/crates/eldenring-archipelago/src/game/progressive.rs
@@ -1,0 +1,340 @@
+//! Phase 5 (Wave C) — progressive grants ported onto the Phase-4 net/grant plumbing.
+//!
+//! "Progressive" AP items ship MORE copies than they have tiers (e.g. `progressive_stone_bell`,
+//! `progressive_physick`): the Kth copy received resolves tier K-1, which sets that tier's shop /
+//! affinity EVENT FLAGS and grants that tier's GOODS, and every copy PAST the last tier is converted
+//! into one Lord's Rune so the surplus copies aren't dead no-ops. This is the Rust port of the
+//! `progressiveGrants` block of `ArchipelagoInterface.cpp` (parse ~216-236, receive ~448-488) and the
+//! `progressive_counter` / `progressive_high_index` persistence in `Core.cpp` (LoadSaveFile ~906-910,
+//! WriteSaveFile ~1069-1089).
+//!
+//! Three-step pattern, IDENTICAL to features.rs:
+//!   1. RECEIVE (net thread, keyed by item NAME): `on_item_received` resolves the tier (index-deduped
+//!      against the persisted `progressive_high_index`), then QUEUES that tier's flags + goods (or one
+//!      overflow Lord's Rune). It returns `true` so the caller SKIPS the normal grant (the C++
+//!      `continue`).
+//!   2. TICK (game thread): `tick` drains the goods queue via `detour::grant_full_id` and the flag
+//!      queue via `flags::try_set_event_flag`, requeuing anything whose holder isn't ready yet —
+//!      exactly like `features::drain_notify_grants` / `flush_grace_flags`.
+//!   3. PERSIST: `progressive_counter` + `progressive_high_index` round-trip through the per-seed save
+//!      OWNED BY grant.rs. This module never writes a save file: it exposes `snapshot()` for
+//!      `grant::write_save` to serialize and `restore()` for `grant::configure` to load, and calls
+//!      `grant::persist()` when a tier advances (see PROGRESSIVE-WIRING.md).
+//!
+//! Thread rule (inherited, CRITICAL): the NAME-keyed tier decision + queueing run on the NET thread
+//! and ONLY touch our own queues + the persisted high-index/counter; every `grant_full_id` and every
+//! event-flag write happens on the FrameBegin TICK. Never touch game memory from the net thread.
+
+#![allow(dead_code)] // wired ahead of every caller while Phase 5 lands
+
+use std::collections::{HashMap, VecDeque};
+use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::{Mutex, OnceLock};
+
+use super::{detour, flags, grant};
+
+// =================================================================================================
+// Parsed config (built once at connect on the net thread; read on every receive on the net thread).
+// =================================================================================================
+
+/// One rung of a progressive item: the GOODS (bare EquipParamGoods ids, goods-packed at grant time)
+/// and the EVENT FLAGS (shop / affinity unlocks) that this tier confers. Mirrors the C++
+/// `std::pair<std::vector<uint32_t> goods, std::vector<uint32_t> flags>`.
+#[derive(Clone, Default)]
+pub struct ProgTier {
+    pub goods: Vec<u32>,
+    pub flags: Vec<u32>,
+}
+
+/// GOODS category nibble (a FullID is `id | (category << 28)`; goods = 0x4). Tier goods + the overflow
+/// Lord's Rune are granted as goods-packed FullIDs, identical to the C++ `| 0x40000000`. Kept in sync
+/// with the same constant in features.rs.
+const GOODS_FULLID: i32 = 0x4000_0000u32 as i32;
+
+/// EquipParamGoods id of a single Lord's Rune (50,000 runes). Granted for every overflow copy past the
+/// last tier — one acquisition popup, like the cosmetic bell. (`ArchipelagoInterface.cpp` ~482.)
+const LORDS_RUNE_GOODS: u32 = 2919;
+
+/// Installed config: progressive item NAME -> ordered tiers. `OnceLock<Mutex<..>>` so the net thread
+/// installs it at connect and reads it on every receipt, matching features.rs's `config()`.
+fn config() -> &'static Mutex<HashMap<String, Vec<ProgTier>>> {
+    static C: OnceLock<Mutex<HashMap<String, Vec<ProgTier>>>> = OnceLock::new();
+    C.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+// =================================================================================================
+// Persisted state (round-trips through grant.rs's per-seed save; see snapshot/restore below).
+// =================================================================================================
+
+/// Per-name tier counter: how many copies of each progressive item have ALREADY advanced a tier.
+/// The Kth advance reads `tiers[K]` then increments (post-increment, like the C++ `[name]++`).
+/// Persisted via `snapshot`/`restore` so reconnects don't recompute tiers from 0.
+fn counter() -> &'static Mutex<HashMap<String, i32>> {
+    static C: OnceLock<Mutex<HashMap<String, i32>>> = OnceLock::new();
+    C.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Highest AP `item.index` already applied to a progressive tier. Only a copy whose `index` exceeds
+/// this advances a tier; replayed copies (reconnect / new session) are skipped. Default -1 so the
+/// first real item (index 0) advances. (`Core->progressiveHighIndex`, default -1.)
+static HIGH_INDEX: AtomicI64 = AtomicI64::new(-1);
+
+// =================================================================================================
+// Cross-thread queues (net thread QUEUES; game tick DRAINS — Step-0 plumbing, same as features.rs).
+// =================================================================================================
+
+/// Goods-packed FullIDs queued (net thread) for the tick to GRANT — tier goods + overflow Lord's
+/// Runes. Drained via `detour::grant_full_id`, requeued on failure (like `drain_notify_grants`).
+fn pending_grants() -> &'static Mutex<VecDeque<i32>> {
+    static Q: OnceLock<Mutex<VecDeque<i32>>> = OnceLock::new();
+    Q.get_or_init(|| Mutex::new(VecDeque::new()))
+}
+
+/// Event flags queued (net thread) for the tick to SET — tier shop/affinity unlocks. SetEventFlag is
+/// idempotent + save-persisted, so a skipped replay needs no re-application (like the grace queue).
+fn pending_flags() -> &'static Mutex<VecDeque<u32>> {
+    static Q: OnceLock<Mutex<VecDeque<u32>>> = OnceLock::new();
+    Q.get_or_init(|| Mutex::new(VecDeque::new()))
+}
+
+// =================================================================================================
+// NET THREAD — parse, install, name-keyed receive.
+// =================================================================================================
+
+/// Net thread, at parse time: tolerantly parse slot_data `progressiveGrants` into name -> tiers.
+///
+/// Shape: an OBJECT mapping each progressive item NAME to an ARRAY of tiers; each tier is an object
+/// with `flags` (array of u32) and EITHER `goodsList` (array of u32) OR `goods` (a scalar u32). A tier
+/// with NEITHER goods key is SKIPPED — never panics. This is the deliberate fix for the C++
+/// "key goods not found" bug, where a throw in the parse aborted the whole slot_data handler and
+/// silently killed ALL item grants. Anything missing/mis-typed is treated as empty, never fatal.
+pub fn parse(sd: &serde_json::Value) -> HashMap<String, Vec<ProgTier>> {
+    let mut out: HashMap<String, Vec<ProgTier>> = HashMap::new();
+    let obj = match sd.get("progressiveGrants").and_then(|v| v.as_object()) {
+        Some(o) => o,
+        None => return out, // absent / wrong type -> no progressive items (older seed = inert)
+    };
+    for (name, tiers_val) in obj {
+        let arr = match tiers_val.as_array() {
+            Some(a) => a,
+            None => continue, // tier list isn't an array -> skip this name, don't panic
+        };
+        let mut tiers: Vec<ProgTier> = Vec::with_capacity(arr.len());
+        for t in arr {
+            let mut tier = ProgTier::default();
+            // flags: optional array of u32.
+            if let Some(fs) = t.get("flags").and_then(|f| f.as_array()) {
+                for f in fs {
+                    if let Some(n) = f.as_u64() {
+                        tier.flags.push(n as u32);
+                    }
+                }
+            }
+            // goods: prefer the `goodsList` array (e.g. progressive_physick = a tear family per step),
+            // else a single scalar `goods` (bells / consumables). A tier with NEITHER is kept only if
+            // it still carries flags; a fully empty tier is dropped (matches "skipped, never thrown").
+            if let Some(gl) = t.get("goodsList").and_then(|g| g.as_array()) {
+                for g in gl {
+                    if let Some(n) = g.as_u64() {
+                        tier.goods.push(n as u32);
+                    }
+                }
+            } else if let Some(g) = t.get("goods").and_then(|g| g.as_u64()) {
+                tier.goods.push(g as u32);
+            }
+            if tier.goods.is_empty() && tier.flags.is_empty() {
+                continue; // nothing to do for this rung -> skip (the C++ "neither key" tolerance)
+            }
+            tiers.push(tier);
+        }
+        out.insert(name.clone(), tiers);
+    }
+    out
+}
+
+/// Net thread, at (re)connect: install the parsed tier table and RESET per-session queues (so a fresh
+/// connect re-queues cleanly). The persisted counter + high-index are NOT reset here — they are
+/// restored from the save by `restore()` (called from grant.rs) and carry across reconnects, which is
+/// what makes the replayed item stream skip already-applied tiers.
+pub fn configure(map: HashMap<String, Vec<ProgTier>>) {
+    *config().lock().unwrap() = map;
+    pending_grants().lock().unwrap().clear();
+    pending_flags().lock().unwrap().clear();
+    let n: usize = config().lock().unwrap().len();
+    if n > 0 {
+        tracing::info!("Progressive: {} progressive item(s) loaded", n);
+    }
+}
+
+/// Net thread: handle ONE received item by NAME. Returns `true` if `name` is a progressive item, so
+/// the caller must SKIP its normal grant enqueue (the C++ `continue`); `false` lets the caller grant
+/// it normally.
+///
+/// Index dedup (CRITICAL): only a copy whose `ap_index` exceeds the persisted `HIGH_INDEX` advances a
+/// tier. Replayed copies on a reconnect / new session are below the high-index and are skipped, so the
+/// persisted counter stays correct across sessions. The shop/affinity flags are ER event flags that
+/// persist in the game save, so a skipped replay needs no re-application. (`ArchipelagoInterface.cpp`
+/// ~448-488.)
+pub fn on_item_received(name: &str, ap_index: i64) -> bool {
+    // Is this a progressive item at all? Clone the tier list so we hold no config lock while touching
+    // the queues (mirrors the lock discipline in features.rs).
+    let tiers = match config().lock().unwrap().get(name) {
+        Some(t) => t.clone(),
+        None => return false, // not progressive -> caller grants normally
+    };
+
+    // Dedup against the persisted high-index. A replayed copy (index <= high) is "handled" (we still
+    // return true to skip the normal grant, exactly like the C++ which `continue`s inside the find)
+    // but advances NO tier.
+    if ap_index <= HIGH_INDEX.load(Ordering::Relaxed) {
+        return true;
+    }
+
+    // Advance the per-name counter: read tier K, then increment (post-increment `[name]++`).
+    let k = {
+        let mut c = counter().lock().unwrap();
+        let slot = c.entry(name.to_string()).or_insert(0);
+        let k = *slot;
+        *slot += 1;
+        k
+    };
+
+    if (k as usize) < tiers.len() {
+        let tier = &tiers[k as usize];
+        let mut flagq = pending_flags().lock().unwrap();
+        for &f in &tier.flags {
+            flagq.push_back(f);
+        }
+        drop(flagq);
+        let mut grantq = pending_grants().lock().unwrap();
+        for &g in &tier.goods {
+            grantq.push_back((g as i32) | GOODS_FULLID);
+        }
+        drop(grantq);
+        tracing::info!(
+            "Progressive '{}' #{}: {} goods + {} shop flag(s)",
+            name,
+            k + 1,
+            tier.goods.len(),
+            tier.flags.len()
+        );
+    } else {
+        // Overflow copy past the last tier: every shop rung this item unlocks is already live, so this
+        // copy would be a dead no-op. Convert it into one Lord's Rune (goods-packed FullID), one
+        // acquisition popup. The index dedup means each REAL overflow copy grants exactly once.
+        pending_grants()
+            .lock()
+            .unwrap()
+            .push_back((LORDS_RUNE_GOODS as i32) | GOODS_FULLID);
+        tracing::info!(
+            "Progressive '{}' #{}: max tier reached -> queued 1 Lord's Rune",
+            name,
+            k + 1
+        );
+    }
+
+    HIGH_INDEX.store(ap_index, Ordering::Relaxed);
+    true
+}
+
+// =================================================================================================
+// GAME THREAD — drain queues (grants + flags), persist when a tier advanced.
+// =================================================================================================
+
+/// Game-thread tick (called from `game::tick`, next to `features::tick`). Drains the progressive goods
+/// queue via `detour::grant_full_id` (requeue on failure, no inventory pointer yet) and the flag queue
+/// via `flags::try_set_event_flag` (requeue if the holder isn't up). When anything landed, persists
+/// the counter + high-index through grant.rs's save (`grant::persist`). No-op until settled in-world
+/// is enforced by the grant/flag holders returning false, exactly like features.rs's drains.
+pub fn tick() {
+    let mut advanced = false;
+    advanced |= drain_grants();
+    advanced |= drain_flags();
+    if advanced {
+        grant::persist();
+    }
+}
+
+/// Drain the goods queue. Mirrors `features::drain_notify_grants`: grant each FullID via the detour;
+/// if the inventory pointer isn't captured yet (`grant_full_id` returns false), requeue and retry next
+/// tick. Returns true if at least one item was granted (so the tick persists the updated high-index).
+fn drain_grants() -> bool {
+    let mut q = pending_grants().lock().unwrap();
+    if q.is_empty() {
+        return false;
+    }
+    let mut granted = 0;
+    let mut requeue: VecDeque<i32> = VecDeque::new();
+    while let Some(addr) = q.pop_front() {
+        if !detour::grant_full_id(addr, 1) {
+            requeue.push_back(addr); // no inventory pointer yet; retry next tick
+            continue;
+        }
+        granted += 1;
+    }
+    *q = requeue;
+    drop(q);
+    if granted > 0 {
+        tracing::info!("Progressive: granted {} queued goods item(s)", granted);
+    }
+    granted > 0
+}
+
+/// Drain the flag queue. Mirrors `features::flush_grace_flags`: set each flag via `try_set_event_flag`;
+/// if the holder (`CSEventFlagMan`) isn't up yet, requeue and retry next tick. SetEventFlag is
+/// idempotent + save-persisted. Returns true if at least one flag landed.
+fn drain_flags() -> bool {
+    let mut q = pending_flags().lock().unwrap();
+    if q.is_empty() {
+        return false;
+    }
+    let mut set_count = 0;
+    let mut retry: VecDeque<u32> = VecDeque::new();
+    while let Some(flag) = q.pop_front() {
+        if flags::try_set_event_flag(flag, true) {
+            set_count += 1;
+            tracing::info!("Progressive shop flag {} SET", flag);
+        } else {
+            retry.push_back(flag); // holder not ready; try next tick
+        }
+    }
+    *q = retry;
+    drop(q);
+    if set_count > 0 {
+        tracing::info!("Progressive: set {} shop flag(s)", set_count);
+    }
+    set_count > 0
+}
+
+// =================================================================================================
+// PERSISTENCE — owned by grant.rs's per-seed save; we only snapshot / restore the two fields.
+// =================================================================================================
+
+/// Snapshot the persisted state for grant.rs to serialize INTO the per-seed save file alongside
+/// `last_received_index`. Returns `(progressive_counter as a JSON object {name: int}, high_index)`,
+/// matching the C++ `k["progressive_counter"]` / `k["progressive_high_index"]` keys.
+pub fn snapshot() -> (serde_json::Value, i64) {
+    let c = counter().lock().unwrap();
+    let map: serde_json::Map<String, serde_json::Value> = c
+        .iter()
+        .map(|(k, &v)| (k.clone(), serde_json::Value::from(v)))
+        .collect();
+    (serde_json::Value::Object(map), HIGH_INDEX.load(Ordering::Relaxed))
+}
+
+/// Restore the persisted state from the per-seed save at (re)connect — called BY grant.rs's
+/// `configure` after it reads the file. `counter` is the `progressive_counter` object ({name: int});
+/// `high_index` is `progressive_high_index` (default -1 if the key was absent). Tolerant: a missing /
+/// mis-typed entry is ignored, never fatal. (`Core.cpp` LoadSaveFile ~906-910.)
+pub fn restore(counter_json: &serde_json::Value, high_index: i64) {
+    let mut c = counter().lock().unwrap();
+    c.clear();
+    if let Some(obj) = counter_json.as_object() {
+        for (name, v) in obj {
+            if let Some(n) = v.as_i64() {
+                c.insert(name.clone(), n as i32);
+            }
+        }
+    }
+    HIGH_INDEX.store(high_index, Ordering::Relaxed);
+}

--- a/crates/eldenring-archipelago/src/game/upgrades.rs
+++ b/crates/eldenring-archipelago/src/game/upgrades.rs
@@ -236,7 +236,11 @@ fn highest_held_level(somber: bool) -> Option<i32> {
         }
         // else: walk failed transiently but we have a cached value -> use it (no down-flicker).
     }
-    Some(if somber { targets.somber } else { targets.normal })
+    Some(if somber {
+        targets.somber
+    } else {
+        targets.normal
+    })
 }
 
 /// One full typed inventory walk: returns (highest normal +N, highest somber +N) across all held
@@ -474,8 +478,10 @@ mod tests {
         // With the feature off, apply_auto_upgrade is a pure identity (no game access).
         set_auto_upgrade(0);
         assert_eq!(apply_auto_upgrade(1_000_007), 1_000_007);
-        assert_eq!(apply_auto_upgrade((er_codec::CATEGORY_GOODS | 2_010_000) as i32),
-                   (er_codec::CATEGORY_GOODS | 2_010_000) as i32);
+        assert_eq!(
+            apply_auto_upgrade((er_codec::CATEGORY_GOODS | 2_010_000) as i32),
+            (er_codec::CATEGORY_GOODS | 2_010_000) as i32
+        );
     }
 
     #[test]

--- a/crates/eldenring-archipelago/src/game/upgrades.rs
+++ b/crates/eldenring-archipelago/src/game/upgrades.rs
@@ -1,0 +1,494 @@
+//! AUTO_UPGRADE + GLOBAL_SCADUTREE_BLESSING — RE holes filled via typed `eldenring` 0.14 bindings.
+//!
+//! Two slot_data features whose game-memory touchpoints were originally RE-stubbed. The RE is now
+//! resolved entirely against the `eldenring` 0.14 typed bindings (NO raw CE offsets are used — every
+//! field that the C++ client reached with a hand-walked offset chain is a NAMED field on a typed
+//! struct here). Every game read/write is read-then-act, raise-only, bounds-checked, and gated on
+//! `super::flags::in_world()` so a mis-resolution degrades to a no-op rather than corrupting a save.
+//!
+//! C++ source of truth (the exact behaviour these port):
+//!   - er_gamehook_win.cpp `AutoUpgradeWeaponIdImpl` (~666) / `RefreshAutoUpgradeTargets` (~609) /
+//!     `WeaponInfo` (~542) / `CapForRT` (~530) (auto_upgrade), and `TickGlobalScaduBlessing` (~720) /
+//!     `SetGlobalScaduBlessing` (~715) / `kScaduCum` (~706) (scadu).
+//!   - ArchipelagoInterface.cpp ~92-100: slot_data `options.auto_upgrade` (int) and
+//!     `options.global_scadutree_blessing` (int) drive `SetAutoUpgrade(int)` / `SetGlobalScaduBlessing(int)`.
+//!
+//! TYPED-BINDING MAP (what replaced each C++ raw-offset hole; see RE-WORKSHEET-autoupgrade-scadu.md):
+//!   - GameDataMan singleton .............. `GameDataMan::instance()` / `::instance_mut()` (FromStatic).
+//!   - PlayerGameData ..................... `gdm.main_player_game_data` (OwnedPtr, `.as_ref()?`/`.as_mut()?`).
+//!                                          (Replaces C++ `*(GameDataMan + 0x08)`.)
+//!   - stored Scadutree blessing .......... `pgd.scadutree_blessing: u8` NAMED field.
+//!                                          (Replaces the raw `PlayerGameData + 0xFC` signed byte.)
+//!   - held-item inventory iterator ....... `pgd.equipment.equip_inventory_data.items_data.items()`
+//!                                          -> `&EquipInventoryDataListEntry` (skips empty slots).
+//!                                          (Replaces the C++ EquipInventoryData container shape-scan.)
+//!   - per-entry item id / category ....... `entry.item_id.param_id() -> u32` + `.category() -> ItemCategory`.
+//!   - per-entry quantity ................. `entry.quantity: u32`.
+//!   - weapon -> reinforceTypeId .......... `repo.get::<EquipParamWeapon>(base).reinforce_type_id() -> i16`.
+//!                                          (Replaces the C++ self-calibrated s16 offset.)
+//!   - reinforce cap ...................... count consecutive `repo.get::<ReinforceParamWeapon>(rt+k)`.
+//!
+//! WIRING (already done elsewhere — do not edit those files):
+//!   - net.rs slot_data parse calls `set_auto_upgrade(..)` / `set_global_scadu_blessing(..)` at connect.
+//!   - detour.rs `grant_full_id` calls `apply_auto_upgrade(full_id) -> i32` on every granted item.
+//!   - mod.rs `tick()` calls `tick_global_scadu()` in the in-world `#[cfg(feature = "net")]` neighbourhood.
+
+#![allow(dead_code)]
+
+use std::sync::atomic::{AtomicI32, Ordering};
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use eldenring::cs::{
+    EquipParamWeapon, GameDataMan, ItemCategory, ReinforceParamWeapon, SoloParamRepository,
+};
+use fromsoftware_shared::FromStatic;
+
+// ---- config (set from slot_data by net.rs; see module doc + worksheet) --------------------------
+
+/// auto_upgrade mode/level from slot_data. The C++ treats it as a simple on/off int
+/// (`g_autoUpgrade = on ? 1 : 0`); we keep the raw int so a future "cap at +N" variant has room.
+/// 0 = off (default). Non-zero = on.
+static AUTO_UPGRADE: AtomicI32 = AtomicI32::new(0);
+
+/// global_scadutree_blessing mode from slot_data: 0 = off, 1 = player_only, 2 = scaled.
+/// (Matches the C++ `g_globalScaduBlessing` tri-state.)
+static GLOBAL_SCADU: AtomicI32 = AtomicI32::new(0);
+
+/// net.rs: `set_auto_upgrade(sd.pointer("/options/auto_upgrade").and_then(|v| v.as_i64()).unwrap_or(0) as i32)`.
+pub fn set_auto_upgrade(level_or_flag: i32) {
+    AUTO_UPGRADE.store(level_or_flag, Ordering::Relaxed);
+    tracing::info!(
+        "auto_upgrade: {}",
+        if level_or_flag != 0 { "ENABLED" } else { "off" }
+    );
+}
+
+/// net.rs: `set_global_scadu_blessing(sd.pointer("/options/global_scadutree_blessing").and_then(|v| v.as_i64()).unwrap_or(0) as i32)`.
+pub fn set_global_scadu_blessing(mode: i32) {
+    let m = if mode == 1 || mode == 2 { mode } else { 0 };
+    GLOBAL_SCADU.store(m, Ordering::Relaxed);
+    tracing::info!(
+        "global_scadu_blessing: {}",
+        if m != 0 { "ENABLED" } else { "off" }
+    );
+}
+
+fn auto_upgrade_on() -> bool {
+    AUTO_UPGRADE.load(Ordering::Relaxed) != 0
+}
+fn scadu_mode() -> i32 {
+    GLOBAL_SCADU.load(Ordering::Relaxed)
+}
+
+// ================================================================================================
+// auto_upgrade
+// ================================================================================================
+//
+// GOAL: when a REAL weapon is acquired, bump it to the player's current highest reinforce level on
+// the same smithing track (normal vs somber) before the game adds it.
+//
+// C++ (er_gamehook_win.cpp `AutoUpgradeWeaponIdImpl`, ~666):
+//   id math: base = id - (id % 100); level = id % 100. ER bakes +N into the id (id = base + N).
+//   track/cap: EquipParamWeapon row(base).reinforceTypeId -> ReinforceParamWeapon; cap = number of
+//     consecutive ReinforceParamWeapon rows from reinforceTypeId; cap>10 => normal (max +25),
+//     cap in 1..=10 => somber (max +10).
+//   target: highest +N currently HELD on that track (walk inventory), clamped to the weapon's cap;
+//     only ever RAISES (returns input if already at/above target).
+//
+// Worksheet §A.
+
+const REINFORCE_STEP: i32 = 100; // ER id stride per smithing level (base = id - id%100)
+const NORMAL_CAP: i32 = 25; // normal smithing track tops out at +25
+const SOMBER_CAP: i32 = 10; // somber smithing track tops out at +10
+
+/// Cached "highest +N held" per track, refreshed on a throttle (C++ used 1500ms + a cached
+/// container offset; the typed iterator removes the container scan, so we just cache the targets
+/// to avoid re-walking the bag on every back-to-back grant in a reconnect replay burst).
+struct UpgradeTargets {
+    normal: i32,
+    somber: i32,
+    last_refresh: Option<Instant>,
+}
+static UPGRADE_TARGETS: Mutex<UpgradeTargets> = Mutex::new(UpgradeTargets {
+    normal: 0,
+    somber: 0,
+    last_refresh: None,
+});
+const REFRESH_THROTTLE: Duration = Duration::from_millis(1500);
+
+/// Given a granted weapon FullID (real item id | category nibble), return the upgraded FullID, or
+/// the input unchanged if it is not an upgradeable weapon / auto_upgrade is off / it can't be
+/// resolved safely. Mirrors the C++ `AutoUpgradeWeaponIdImpl`.
+///
+/// CALL SITE: detour.rs `grant_full_id` (every AP-granted item funnels through it). Returns the
+/// input unchanged for non-weapons and whenever any read can't be done safely (raise-only by
+/// construction: never lowers an already-higher granted weapon).
+pub fn apply_auto_upgrade(full_id: i32) -> i32 {
+    if !auto_upgrade_on() {
+        return full_id;
+    }
+    // Only touch game memory in-world (params + inventory loaded). Mirrors the param-probe gate;
+    // before the world is up the SoloParamRepository / GameDataMan singletons fault.
+    if !super::flags::in_world() {
+        return full_id;
+    }
+    // Decode base/level + category guard (pure). Only WEAPON-category FullIDs proceed.
+    let Some((base, level)) = decode_weapon_id(full_id) else {
+        return full_id;
+    };
+
+    // EquipParamWeapon row(base) -> reinforceTypeId, then ReinforceParamWeapon consecutive-row cap.
+    let Some((cap, somber)) = weapon_track_and_cap(base) else {
+        return full_id; // not an upgradeable weapon (no param row / cap 0) -> inert
+    };
+
+    // Highest +N held on this track. None => couldn't resolve the bag safely -> inert (no guess).
+    let Some(target_raw) = highest_held_level(somber) else {
+        return full_id;
+    };
+
+    let mut target = target_raw;
+    if target > cap {
+        target = cap;
+    }
+    if target <= level {
+        return full_id; // already at/above target — return unchanged (C++ returns false)
+    }
+    let up = base + target;
+    tracing::info!(
+        "auto_upgrade: weapon {:#x} (+{}) -> +{} ({} track, cap +{})",
+        base,
+        level,
+        target,
+        if somber { "somber" } else { "normal" },
+        cap
+    );
+    // Re-attach the category nibble. WEAPON category is 0x0, so for a weapon this is a no-op, but we
+    // keep the mask symmetric with decode_weapon_id (C++ rewrites base+target with category 0).
+    (full_id & !(ROW_ID_MASK as i32)) | (up & ROW_ID_MASK as i32)
+}
+
+/// ER category nibble mask / weapon-category constant (er_codec mirror; weapons are category 0x0).
+const ROW_ID_MASK: u32 = er_codec::ROW_ID_MASK;
+
+/// Pure id-math decode: returns (base_row_id, level) for an upgradeable WEAPON FullID, else None.
+/// base = row - row%100; level = row%100. Category guard mirrors C++ `WeaponInfo`:
+///   `(uint32(itemId) & CATEGORY_MASK) != CATEGORY_WEAPON` rejects non-weapons; row range
+///   `[1_000_000, 90_000_000)` skips system/NPC ids. Weapons are er_codec::CATEGORY_WEAPON (0x0).
+fn decode_weapon_id(full_id: i32) -> Option<(i32, i32)> {
+    // RE-A1 RESOLVED: category test via er_codec constants (CATEGORY_WEAPON == 0x0, CATEGORY_MASK).
+    if er_codec::item_category_of(full_id as u32) != er_codec::CATEGORY_WEAPON {
+        return None;
+    }
+    let row = (full_id as u32 & ROW_ID_MASK) as i32;
+    if !(1_000_000..90_000_000).contains(&row) {
+        return None;
+    }
+    let base = row - (row % REINFORCE_STEP);
+    let level = row % REINFORCE_STEP;
+    Some((base, level))
+}
+
+/// RE-A2 RESOLVED (typed binding): resolve a weapon base id -> (reinforce cap, is_somber).
+/// `repo.get::<EquipParamWeapon>(base).reinforce_type_id() -> i16`; then cap = max k in [0,25] s.t.
+/// `repo.get::<ReinforceParamWeapon>(rt + k)` exists. somber = cap <= 10. Mirrors C++ `CapForRT` /
+/// `WeaponInfo`. None (no upgrade) if the repo isn't up, the row is absent, or cap <= 0.
+fn weapon_track_and_cap(base: i32) -> Option<(i32, bool)> {
+    // SAFETY: FD4 singleton; on the game thread, gated in-world by the caller. Err until built.
+    let repo = unsafe { SoloParamRepository::instance() }.ok()?;
+    let weapon = repo.get::<EquipParamWeapon>(base as u32)?;
+    let rt = weapon.reinforce_type_id() as i32;
+    // Count consecutive ReinforceParamWeapon rows from rt. C++: `while (k<=25 && row(rt+k)) ++k;
+    // cap = k-1`. rt can be negative for non-upgradeable junk; get() just returns None then.
+    let mut k = 0;
+    while k <= NORMAL_CAP && repo.get::<ReinforceParamWeapon>((rt + k) as u32).is_some() {
+        k += 1;
+    }
+    let cap = k - 1;
+    if cap <= 0 {
+        return None; // not upgradeable
+    }
+    let somber = cap <= SOMBER_CAP;
+    Some((cap, somber))
+}
+
+/// RE-A3 RESOLVED (typed binding): highest +N currently held on the given smithing track
+/// (true = somber). Walks `GameDataMan -> main_player_game_data -> equipment.equip_inventory_data
+/// .items_data.items()` (the typed iterator skips empty slots). Caches the per-track maxima behind a
+/// 1500ms throttle so a reconnect replay burst doesn't re-walk the bag per grant (mirrors C++
+/// `RefreshAutoUpgradeTargets`). Returns None only if the bag can't be resolved AND nothing is
+/// cached yet (so the caller leaves the weapon unchanged rather than guessing).
+fn highest_held_level(somber: bool) -> Option<i32> {
+    let mut targets = UPGRADE_TARGETS.lock().ok()?;
+    let stale = match targets.last_refresh {
+        Some(t) => t.elapsed() >= REFRESH_THROTTLE,
+        None => true,
+    };
+    if stale {
+        if let Some((normal, somber_max)) = walk_inventory_targets() {
+            targets.normal = normal;
+            targets.somber = somber_max;
+            targets.last_refresh = Some(Instant::now());
+        } else if targets.last_refresh.is_none() {
+            // Never resolved the bag and nothing cached -> can't supply a target yet.
+            return None;
+        }
+        // else: walk failed transiently but we have a cached value -> use it (no down-flicker).
+    }
+    Some(if somber { targets.somber } else { targets.normal })
+}
+
+/// One full typed inventory walk: returns (highest normal +N, highest somber +N) across all held
+/// weapons, or None if the bag isn't reachable this tick. Pure read; no writes. Each weapon entry's
+/// `param_id()` is the resolved row (base + level); we re-classify its track via the same param cap
+/// rule so a weapon's level is only counted toward the track it actually belongs to.
+fn walk_inventory_targets() -> Option<(i32, i32)> {
+    // SAFETY: FD4 singleton (read-only walk). Err/None before the player is placed.
+    let gdm = unsafe { GameDataMan::instance() }.ok()?;
+    let pgd = gdm.main_player_game_data.as_ref();
+    let mut normal = 0i32;
+    let mut somber = 0i32;
+    for entry in pgd.equipment.equip_inventory_data.items_data.items() {
+        if entry.item_id.category() != ItemCategory::Weapon {
+            continue;
+        }
+        // param_id() strips the category nibble -> the resolved weapon row (base + level).
+        let row = entry.item_id.param_id() as i32;
+        if !(1_000_000..90_000_000).contains(&row) {
+            continue;
+        }
+        let level = row % REINFORCE_STEP;
+        let base = row - level;
+        // Classify the held weapon by its OWN track (a somber weapon can never reach +25, so its
+        // level must not raise the normal target, and vice-versa). Mirrors C++ WeaponInfo per entry.
+        match weapon_track_and_cap(base) {
+            Some((_, true)) => {
+                if level > somber {
+                    somber = level;
+                }
+            }
+            Some((_, false)) => {
+                if level > normal {
+                    normal = level;
+                }
+            }
+            None => {}
+        }
+    }
+    Some((normal, somber))
+}
+
+// ================================================================================================
+// global_scadutree_blessing
+// ================================================================================================
+//
+// GOAL: count held Scadutree Fragments, map to a blessing level via the vanilla cost curve, and
+// write the stored combat-blessing field on PlayerGameData so the base game applies the buff.
+//
+// C++ (er_gamehook_win.cpp `TickGlobalScaduBlessing`, ~720):
+//   fragments: ONE inventory stack, goods id 2010000 (FullID = 2010000 | CATEGORY_GOODS); qty = total.
+//   curve: kScaduCum[0..20] cumulative-fragments-to-reach-level table -> level 0..20.
+//   write: PlayerGameData + 0xFC, signed byte (the stored combat blessing). Only ever RAISE. Engine
+//     recomputes the speffect from this byte on next map load / grace rest. Throttled to once/second.
+//   The raw `PlayerGameData + 0xFC` offset is replaced here by the NAMED typed field
+//   `PlayerGameData::scadutree_blessing: u8` (eldenring 0.14) — same datum, version-robust.
+//
+// Worksheet §B.
+
+/// Scadutree Fragment goods row id (no category nibble). FullID = SCADU_FRAGMENT_GOODS | category.
+const SCADU_FRAGMENT_GOODS: u32 = 2_010_000;
+
+/// Cumulative Scadutree Fragments required to REACH each combat-blessing level (index = level 0..20).
+/// Verbatim from C++ `kScaduCum`. Pure data — no RE needed.
+const SCADU_CUM: [i32; 21] = [
+    0, 1, 3, 5, 7, 9, 11, 13, 15, 17, 20, 23, 26, 29, 32, 35, 38, 41, 44, 47, 50,
+];
+
+/// Maximum stored blessing level the game's combat-blessing curve defines (caps the raise-only write).
+const SCADU_MAX_LEVEL: i32 = 20;
+
+/// Map a held-fragment count to a blessing level (0..20). Pure; highest L with frags >= SCADU_CUM[L].
+fn level_for_fragments(frag_qty: i32) -> i32 {
+    let mut level = 0;
+    for l in (0..=20).rev() {
+        if frag_qty >= SCADU_CUM[l as usize] {
+            level = l;
+            break;
+        }
+    }
+    level
+}
+
+/// Scadu writer throttle (~1s, mirrors C++ `s_lastTick`). A stored-byte watchdog doesn't need to run
+/// every frame; this also keeps the bag walk cheap.
+static SCADU_LAST_TICK: Mutex<Option<Instant>> = Mutex::new(None);
+const SCADU_THROTTLE: Duration = Duration::from_millis(1000);
+
+/// Per-tick stored-blessing writer. Call from the in-world feature tick (mod.rs `tick()`).
+/// Self-gates: returns immediately when the mode is off or out-of-world. Throttled to ~1s. Reads the
+/// held Scadutree Fragment count, maps it to a level, and raises `PlayerGameData::scadutree_blessing`
+/// (never lowers a real/higher DLC value). mode 1 (player_only) and mode 2 (scaled) behave the same
+/// here — exactly as the C++ `TickGlobalScaduBlessing` does (it gates on `g_globalScaduBlessing`
+/// being non-zero and applies the player byte for both; the "scaled" variant is a future apworld
+/// concern with no extra client write, so mode 2 is a documented no-extra-op alias of mode 1).
+pub fn tick_global_scadu() {
+    if scadu_mode() == 0 {
+        return;
+    }
+    // GATE: only touch game memory in-world (params + inventory loaded). Same gate the param probe
+    // uses (mod.rs `tick()` gates `spike_log_goods_rowcount` on `flags::in_world()`).
+    if !super::flags::in_world() {
+        return;
+    }
+    // Throttle (~1s). Cheap watchdog cadence; keeps the bag walk off the hot path.
+    {
+        let mut last = match SCADU_LAST_TICK.lock() {
+            Ok(g) => g,
+            Err(_) => return,
+        };
+        if let Some(t) = *last {
+            if t.elapsed() < SCADU_THROTTLE {
+                return;
+            }
+        }
+        *last = Some(Instant::now());
+    }
+
+    // Read total held Scadutree Fragments (goods 2010000). None => bag not reachable this tick ->
+    // inert (never writes a transient 0; avoids flicker if the walk raced a realloc, like the C++).
+    let Some(frag_qty) = held_scadu_fragments() else {
+        return;
+    };
+
+    let level = level_for_fragments(frag_qty);
+
+    // Read the current stored blessing, then ONLY raise it (never stomp a higher real DLC revere,
+    // never down-flicker). The read+write share one mutable PlayerGameData borrow inside
+    // `raise_stored_blessing` so the value can't change between the compare and the store.
+    match raise_stored_blessing(level) {
+        Some(Some((was, now))) => {
+            tracing::info!(
+                "global_scadu_blessing: frags={} -> blessing level {} (PlayerGameData.scadutree_blessing, was {})",
+                frag_qty,
+                now,
+                was
+            );
+        }
+        Some(None) => {} // already >= target; nothing written
+        None => {}       // PlayerGameData unreachable this tick; retry next throttle window
+    }
+}
+
+/// RE-B1 RESOLVED (typed binding): total held Scadutree Fragments (goods 2010000). Walks the same
+/// typed inventory iterator as auto_upgrade and sums the quantity of every goods entry whose
+/// `param_id()` is the fragment row. (Both AP fragment variants share goods id 2010000, so this is
+/// effectively one stack; summing is safe even if the game ever splits it.) None if the bag isn't
+/// reachable this tick. Read-only.
+fn held_scadu_fragments() -> Option<i32> {
+    // SAFETY: FD4 singleton (read-only walk). None before the player is placed.
+    let gdm = unsafe { GameDataMan::instance() }.ok()?;
+    let pgd = gdm.main_player_game_data.as_ref();
+    let mut total: i64 = 0;
+    for entry in pgd.equipment.equip_inventory_data.items_data.items() {
+        if entry.item_id.category() != ItemCategory::Goods {
+            continue;
+        }
+        if entry.item_id.param_id() == SCADU_FRAGMENT_GOODS {
+            total += entry.quantity as i64;
+        }
+    }
+    // ER stacks cap well under i32; clamp defensively.
+    if total > i32::MAX as i64 {
+        total = i32::MAX as i64;
+    }
+    Some(total as i32)
+}
+
+/// RE-B2 / RE-B3 RESOLVED (typed binding): read the current stored combat-blessing level and RAISE
+/// it to `level` if higher. Returns:
+///   - `Some(Some((was, now)))` — wrote a new (raised) value,
+///   - `Some(None)`             — current was already >= target; left untouched,
+///   - `None`                   — PlayerGameData not reachable this tick.
+/// Uses `PlayerGameData::scadutree_blessing: u8` (named field; replaces the raw `PGD + 0xFC` byte).
+/// Read + write share one `instance_mut()` borrow so nothing can change between compare and store.
+fn raise_stored_blessing(level: i32) -> Option<Option<(i32, i32)>> {
+    // Clamp the computed target into the valid stored range before any write.
+    let mut target = level;
+    if target < 0 {
+        target = 0;
+    }
+    if target > SCADU_MAX_LEVEL {
+        target = SCADU_MAX_LEVEL;
+    }
+    // SAFETY: FD4 singleton accessed MUTABLY (we may write the byte); same idiom as
+    // deathlink.rs `WorldChrMan::instance_mut()`. Err/None before the player is placed -> no-op.
+    let gdm = unsafe { GameDataMan::instance_mut() }.ok()?;
+    let pgd = gdm.main_player_game_data.as_mut();
+    let cur = pgd.scadutree_blessing as i32;
+    if cur >= target {
+        return Some(None); // already >= target; never lower
+    }
+    pgd.scadutree_blessing = target as u8;
+    Some(Some((cur, target)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scadu_curve_matches_cpp_table() {
+        // Boundary checks against kScaduCum.
+        assert_eq!(level_for_fragments(0), 0);
+        assert_eq!(level_for_fragments(1), 1);
+        assert_eq!(level_for_fragments(2), 1); // 2 frags still level 1 (next is 3)
+        assert_eq!(level_for_fragments(3), 2);
+        assert_eq!(level_for_fragments(49), 19);
+        assert_eq!(level_for_fragments(50), 20);
+        assert_eq!(level_for_fragments(999), 20); // capped at 20
+    }
+
+    #[test]
+    fn weapon_id_math() {
+        // base/level split for a +7 weapon row (category 0x0 weapon; row 1000007 -> base 1000000, level 7).
+        assert_eq!(decode_weapon_id(1_000_007), Some((1_000_000, 7)));
+        // a weapon at +0 decodes to (base, 0).
+        assert_eq!(decode_weapon_id(2_000_000), Some((2_000_000, 0)));
+        // out-of-range weapon row ids decode to None.
+        assert_eq!(decode_weapon_id(500), None);
+        // a GOODS-category id (category nibble 0x4) is NOT a weapon -> None even if row is in range.
+        assert_eq!(
+            decode_weapon_id((er_codec::CATEGORY_GOODS | 2_010_000) as i32),
+            None
+        );
+        // a PROTECTOR-category id (nibble 0x1) is rejected too.
+        assert_eq!(
+            decode_weapon_id((er_codec::CATEGORY_PROTECTOR | 1_000_000) as i32),
+            None
+        );
+    }
+
+    #[test]
+    fn apply_auto_upgrade_off_is_identity() {
+        // With the feature off, apply_auto_upgrade is a pure identity (no game access).
+        set_auto_upgrade(0);
+        assert_eq!(apply_auto_upgrade(1_000_007), 1_000_007);
+        assert_eq!(apply_auto_upgrade((er_codec::CATEGORY_GOODS | 2_010_000) as i32),
+                   (er_codec::CATEGORY_GOODS | 2_010_000) as i32);
+    }
+
+    #[test]
+    fn scadu_mode_clamp() {
+        // set_global_scadu_blessing clamps to {0,1,2}.
+        set_global_scadu_blessing(0);
+        assert_eq!(scadu_mode(), 0);
+        set_global_scadu_blessing(1);
+        assert_eq!(scadu_mode(), 1);
+        set_global_scadu_blessing(2);
+        assert_eq!(scadu_mode(), 2);
+        set_global_scadu_blessing(7); // out of range -> off
+        assert_eq!(scadu_mode(), 0);
+        set_global_scadu_blessing(0);
+    }
+}

--- a/crates/eldenring-archipelago/src/game/upgrades.rs
+++ b/crates/eldenring-archipelago/src/game/upgrades.rs
@@ -1,3 +1,8 @@
+#![allow(
+    clippy::doc_overindented_list_items,
+    clippy::doc_lazy_continuation,
+    clippy::collapsible_match
+)]
 //! AUTO_UPGRADE + GLOBAL_SCADUTREE_BLESSING — RE holes filled via typed `eldenring` 0.14 bindings.
 //!
 //! Two slot_data features whose game-memory touchpoints were originally RE-stubbed. The RE is now
@@ -419,12 +424,7 @@ fn held_scadu_fragments() -> Option<i32> {
 fn raise_stored_blessing(level: i32) -> Option<Option<(i32, i32)>> {
     // Clamp the computed target into the valid stored range before any write.
     let mut target = level;
-    if target < 0 {
-        target = 0;
-    }
-    if target > SCADU_MAX_LEVEL {
-        target = SCADU_MAX_LEVEL;
-    }
+    target = target.clamp(0, SCADU_MAX_LEVEL);
     // SAFETY: FD4 singleton accessed MUTABLY (we may write the byte); same idiom as
     // deathlink.rs `WorldChrMan::instance_mut()`. Err/None before the player is placed -> no-op.
     let gdm = unsafe { GameDataMan::instance_mut() }.ok()?;

--- a/crates/eldenring-archipelago/src/lib.rs
+++ b/crates/eldenring-archipelago/src/lib.rs
@@ -120,7 +120,8 @@ mod tests {
     fn end_to_end_decode_through_reexport() {
         // A synthetic local-replacement goods placeholder decodes + routes to SuppressAndGrant.
         let mut row = [0u8; er_codec::EQG_ROW_SIZE];
-        row[er_codec::EQG_OFF_VAGRANT_ITEM_LOT_ID..][..4].copy_from_slice(&7_004_362i32.to_le_bytes());
+        row[er_codec::EQG_OFF_VAGRANT_ITEM_LOT_ID..][..4]
+            .copy_from_slice(&7_004_362i32.to_le_bytes());
         row[er_codec::EQG_OFF_BASIC_PRICE..][..4].copy_from_slice(&1_000_000i32.to_le_bytes());
         row[er_codec::EQG_OFF_SELL_VALUE..][..4].copy_from_slice(&1i32.to_le_bytes());
         let item = decode_synthetic_row(&row).unwrap();

--- a/crates/eldenring-archipelago/src/lib.rs
+++ b/crates/eldenring-archipelago/src/lib.rs
@@ -91,7 +91,7 @@ mod game;
 pub unsafe extern "C" fn DllMain(_hmodule: u64, reason: u32) -> bool {
     const DLL_PROCESS_ATTACH: u32 = 1;
     if reason == DLL_PROCESS_ATTACH {
-        std::thread::spawn(|| game::init());
+        std::thread::spawn(game::init);
     }
     true
 }

--- a/crates/eldenring-archipelago/src/lib.rs
+++ b/crates/eldenring-archipelago/src/lib.rs
@@ -1,0 +1,131 @@
+//! ER Archipelago runtime client — Rust spike (Phase 1 / 3 of SPEC-rust-client-port.md).
+//!
+//! This crate is the in-process, injected DLL. It is intentionally a thin shell over two pure,
+//! host-tested crates:
+//!   * [`er_codec`]  — synthetic detection, sign-safe location-id recombine, EquipParamGoods read.
+//!   * [`er_semver`] — the node-semver lockstep gate.
+//!
+//! Everything that needs the live game (singleton resolution, the `AddItemFunc` detour, event-flag
+//! reporting) lives under `#[cfg(windows)]` and builds on `fromsoftware-rs` + `retour`. On a
+//! non-Windows host this whole module compiles out, so the workspace still builds and `cargo test`s
+//! in CI; only the pure logic is exercised there.
+//!
+//! Scope of THIS spike (SPEC §4 phase 1): prove the single biggest assumption — that the
+//! `fromsoftware-rs` `eldenring` crate exposes what we need — by resolving `SoloParamRepository`
+//! and logging the EquipParamGoods rowCount, then decoding one synthetic pickup end-to-end. The
+//! large ER feature surface (region fusion, natural keys, progressive bells, sweeps, …) is NOT in
+//! this crate yet; see SPEC §4 phase 5.
+
+/// The client's own lockstep contract version. Must sit inside the band the apworld emits over the
+/// `versions` slot_data (checked at connect via [`er_semver::version_satisfies`]). Keep in step with
+/// the apworld range and the randomizer bake constant — do NOT bump during the port.
+pub const CONTRACT_VERSION: &str = "0.1.0-beta.2";
+
+/// Re-exported so the in-process layer and tests share one decision function.
+pub use er_codec::{decide_pickup, decode_synthetic_row, is_synthetic_goods, PickupAction};
+
+/// Check our contract version against a server-supplied range. Thin wrapper kept here so callers
+/// don't need to know which semver crate backs it.
+pub fn contract_satisfies(range: &str) -> bool {
+    er_semver::version_satisfies(CONTRACT_VERSION, range).unwrap_or(false)
+}
+
+/// Format a UNIX-epoch second count as `YYYYMMDD_HHMMSS` (UTC) for log file names. Pure + host-
+/// tested (Hinnant civil-from-days), so the timestamp the in-process logger stamps into the file
+/// name is verified off Windows. Saturates to "00000000_000000" only if called with secs=0.
+#[allow(dead_code)] // used by log_timestamp() (Windows) and the tests (any host)
+pub(crate) fn fmt_utc_compact(secs: u64) -> String {
+    let days = (secs / 86_400) as i64;
+    let tod = secs % 86_400;
+    let (hh, mm, ss) = (tod / 3600, (tod % 3600) / 60, tod % 60);
+    let z = days + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = z - era * 146_097;
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    format!("{:04}{:02}{:02}_{:02}{:02}{:02}", y, m, d, hh, mm, ss)
+}
+
+/// Current UTC time as `YYYYMMDD_HHMMSS` (for the per-launch log file name).
+#[cfg(windows)]
+pub(crate) fn log_timestamp() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    fmt_utc_compact(secs)
+}
+
+// =================================================================================================
+// In-process layer (Windows only). Everything below requires the live game + fromsoftware-rs.
+// =================================================================================================
+//
+// Lives under `#[cfg(windows)]` so the workspace still builds/tests on Linux/macOS (the modules
+// below pull `eldenring` / `retour` / `windows`, which are target-gated in Cargo.toml).
+#[cfg(windows)]
+mod game;
+
+/// DLL entry point.
+///
+/// Signature matches the me3 / libraryloader convention used across the fromsoftware-rs examples
+/// (`reason == 1` is PROCESS_ATTACH). This is the loader we're converging on; for a raw OS
+/// `LoadLibrary` / ModEngine2 path the 3-arg Win32 `DllMain` is needed instead — keep both behind a
+/// feature if EML/ME2 support is still required (the C++ client's `StandaloneInit`-from-DllMain
+/// design did exactly this; see SPEC §6).
+///
+/// We never do real work on the loader lock: spawn a worker thread and return immediately.
+///
+/// # Safety
+/// Exposed for the loader to call. Do not call this yourself.
+#[cfg(windows)]
+// DllMain MUST be `no_mangle` + `unsafe extern "C"` so the loader can find and call it by name —
+// expected here, not a code smell, so allow it on this one item (the rest of the shell stays strict).
+#[allow(unsafe_code)]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn DllMain(_hmodule: u64, reason: u32) -> bool {
+    const DLL_PROCESS_ATTACH: u32 = 1;
+    if reason == DLL_PROCESS_ATTACH {
+        std::thread::spawn(|| game::init());
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn timestamp_format_matches_reference() {
+        // Reference values cross-checked against Python datetime.utcfromtimestamp.
+        assert_eq!(fmt_utc_compact(0), "19700101_000000");
+        assert_eq!(fmt_utc_compact(1_700_000_000), "20231114_221320");
+        assert_eq!(fmt_utc_compact(1_750_700_000), "20250623_173320");
+        assert_eq!(fmt_utc_compact(253_402_300_799), "99991231_235959");
+    }
+
+    #[test]
+    fn contract_version_is_in_its_own_band() {
+        // The lockstep band SYNC-RUNBOOK.md documents; our CONTRACT_VERSION must satisfy it.
+        assert!(contract_satisfies(">=0.1.0-beta.2 <0.1.0-beta.3"));
+        assert!(!contract_satisfies(">=0.1.0 <0.2.0")); // pre-release rejected by graduated band
+    }
+
+    #[test]
+    fn end_to_end_decode_through_reexport() {
+        // A synthetic local-replacement goods placeholder decodes + routes to SuppressAndGrant.
+        let mut row = [0u8; er_codec::EQG_ROW_SIZE];
+        row[er_codec::EQG_OFF_VAGRANT_ITEM_LOT_ID..][..4].copy_from_slice(&7_004_362i32.to_le_bytes());
+        row[er_codec::EQG_OFF_BASIC_PRICE..][..4].copy_from_slice(&1_000_000i32.to_le_bytes());
+        row[er_codec::EQG_OFF_SELL_VALUE..][..4].copy_from_slice(&1i32.to_le_bytes());
+        let item = decode_synthetic_row(&row).unwrap();
+        assert_eq!(item.ap_location_id, 7_004_362);
+        assert_eq!(decide_pickup(&item), PickupAction::SuppressAndGrant);
+        assert!(is_synthetic_goods(er_codec::CATEGORY_GOODS | 4_000_000));
+    }
+}

--- a/crates/er-codec/Cargo.toml
+++ b/crates/er-codec/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "er-codec"
+version = "0.1.0"
+edition = "2021"
+description = "Pure, host-testable decode core for the ER Archipelago client (synthetic-placeholder detection, sign-safe location-id recombine, EquipParamGoods row read). Port of er_item_decode.h + er_goods_row.h."
+license = "MIT"
+
+[lints.rust]
+unsafe_code = "forbid"

--- a/crates/er-codec/src/lib.rs
+++ b/crates/er-codec/src/lib.rs
@@ -1,0 +1,296 @@
+//! ER Archipelago runtime-client decode core — Rust port of `er_item_decode.h` + `er_goods_row.h`.
+//!
+//! Portable, Windows-free, unit-testable. Encodes the LOCKED decode contract (decisions A–F):
+//!  - Goods-only routing: every synthetic placeholder is an `EquipParamGoods` row. Detection =
+//!    goods category + row id > 3,780,000 (Decision D).
+//!  - Location id = `vagrantItemLotId` (low 32) + `vagrantBonusEneDropItemLotId` (high 32), each
+//!    stored SIGNED `i32` in the ER paramdef -> the recombine MUST cast through `u32` (see
+//!    [`recombine_location_id`]).
+//!  - Local replacement = `basicPrice` (real item id; 0 = no local item) + `sellValue` (qty).
+//!  - Foreign-remove = the `disableUseAtOutOfColiseum` bit (ER paramdef spelling, capital O-F).
+//!
+//! This crate is the *transform + offset* layer only. Resolving the in-memory row pointer (the
+//! `ParamBase` walk) lives in the in-process `eldenring-ap` crate; this layer takes a `&[u8]` row
+//! so it stays host-testable against synthetic rows (see tests).
+
+// ---- category nibble (top 4 bits of a "gib" item id; ER scheme, inherited from DS3) ------------
+
+pub const CATEGORY_WEAPON: u32 = 0x0000_0000;
+pub const CATEGORY_PROTECTOR: u32 = 0x1000_0000;
+pub const CATEGORY_ACCESSORY: u32 = 0x2000_0000;
+pub const CATEGORY_GOODS: u32 = 0x4000_0000;
+pub const CATEGORY_MASK: u32 = 0xF000_0000;
+pub const ROW_ID_MASK: u32 = 0x0FFF_FFFF;
+
+/// Decision D, post goods-only: a synthetic placeholder is a goods row whose category-stripped id
+/// exceeds this. Bounds vanilla goods comfortably (max real vanilla goods id = 2,220,010).
+pub const SYNTHETIC_GOODS_MIN_ID: u32 = 3_780_000;
+
+#[inline]
+pub fn item_category_of(q_item_id: u32) -> u32 {
+    q_item_id & CATEGORY_MASK
+}
+
+#[inline]
+pub fn row_id_of(q_item_id: u32) -> u32 {
+    q_item_id & ROW_ID_MASK
+}
+
+/// True iff a picked-up gib id is one of our synthetic placeholders. Goods-only: a real item in any
+/// other category is never synthetic, regardless of how large its id is (e.g. the ~99M NPC weapons).
+#[inline]
+pub fn is_synthetic_goods(q_item_id: u32) -> bool {
+    item_category_of(q_item_id) == CATEGORY_GOODS && row_id_of(q_item_id) > SYNTHETIC_GOODS_MIN_ID
+}
+
+/// Recombine the `i64` AP location id from the two vagrant carrier fields.
+///
+/// CRITICAL: `vagrantItemLotId` / `vagrantBonusEneDropItemLotId` are SIGNED `i32` in the ER
+/// paramdef (vanilla stores -1, which an unsigned field can't hold). The `as u32` casts are
+/// load-bearing: the naive signed widen `((low as i64) | ((high as i64) << 32))` sign-extends any
+/// half whose bit 31 is set and clobbers the other half. ER's live ids are all in
+/// `[7_000_000, 7_004_362]` (bit-31 clear, high word zero), so there is no live corruption today
+/// and a byte-diff is blind to this — the fix is validated only by the bit-31 vectors below.
+#[inline]
+pub fn recombine_location_id(vagrant_low: i32, vagrant_high: i32) -> i64 {
+    (vagrant_low as u32 as i64) | ((vagrant_high as u32 as i64) << 32)
+}
+
+/// Field values read off a synthetic `EquipParamGoods` row.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GoodsRowFields {
+    /// location id, low 32
+    pub vagrant_item_lot_id: i32,
+    /// location id, high 32
+    pub vagrant_bonus_ene_drop_item_lot_id: i32,
+    /// local real item id; 0 => no local item (foreign)
+    pub basic_price: i32,
+    /// local quantity
+    pub sell_value: i32,
+    /// foreign-remove flag
+    pub disable_use_at_out_of_coliseum: bool,
+}
+
+/// Decoded synthetic placeholder.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SyntheticItem {
+    pub ap_location_id: i64,
+    /// 0 => no local grant
+    pub local_item_id: i32,
+    pub local_quantity: i32,
+    /// report the check, remove the placeholder, grant nothing locally
+    pub foreign_remove: bool,
+}
+
+#[inline]
+pub fn decode_synthetic(f: &GoodsRowFields) -> SyntheticItem {
+    SyntheticItem {
+        ap_location_id: recombine_location_id(
+            f.vagrant_item_lot_id,
+            f.vagrant_bonus_ene_drop_item_lot_id,
+        ),
+        local_item_id: f.basic_price,
+        local_quantity: f.sell_value,
+        foreign_remove: f.disable_use_at_out_of_coliseum,
+    }
+}
+
+/// What the detour should do with a confirmed synthetic placeholder (port of `PickupAction`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PickupAction {
+    /// foreign / no-local: drop the placeholder, report the check only
+    Suppress,
+    /// local: drop the placeholder, grant (local_item_id, local_quantity)
+    SuppressAndGrant,
+}
+
+#[inline]
+pub fn decide_pickup(s: &SyntheticItem) -> PickupAction {
+    if !s.foreign_remove && s.local_item_id != 0 {
+        PickupAction::SuppressAndGrant
+    } else {
+        PickupAction::Suppress
+    }
+}
+
+// ---- EquipParamGoods row offsets (port of er_goods_row.h) ---------------------------------------
+//
+// Offsets computed from ER Paramdex EquipParamGoods.xml (EQUIP_PARAM_GOODS_ST, FormatVersion 203,
+// little-endian) and validated three ways (row size 176, Smithbox CSV ordinals, type-preserving
+// name diffs). A paramdef bump touches only this block.
+
+pub const EQG_ROW_SIZE: usize = 176; // 0xB0
+pub const EQG_OFF_BASIC_PRICE: usize = 0x10; // i32, ordinal 6
+pub const EQG_OFF_SELL_VALUE: usize = 0x14; // i32, ordinal 7
+pub const EQG_OFF_DISABLE_USE_AT_OUT_OF_COLISEUM: usize = 0x4A; // u8 bitfield byte, ordinal 54
+pub const EQG_BIT_DISABLE_USE_AT_OUT_OF_COLISEUM: u8 = 0x20; // bit 5 of that byte
+pub const EQG_OFF_VAGRANT_ITEM_LOT_ID: usize = 0x54; // i32, ordinal 60
+pub const EQG_OFF_VAGRANT_BONUS_ENE_DROP_ITEM_LOT_ID: usize = 0x58; // i32, ordinal 61
+
+/// Alignment-safe little-endian `i32` load (the param blob is LE, matching the x64 host). Returns
+/// `None` if the offset would read past the slice — the C++ raw-pointer version can't express this,
+/// so the Rust port hardens the boundary instead of trusting the caller.
+#[inline]
+pub fn read_i32(row: &[u8], off: usize) -> Option<i32> {
+    let bytes = row.get(off..off + 4)?;
+    Some(i32::from_le_bytes(bytes.try_into().unwrap()))
+}
+
+/// Pull the synthetic-carrier fields out of a raw `EquipParamGoods` row. Returns `None` if `row`
+/// is shorter than the highest offset touched.
+pub fn read_goods_row(row: &[u8]) -> Option<GoodsRowFields> {
+    Some(GoodsRowFields {
+        vagrant_item_lot_id: read_i32(row, EQG_OFF_VAGRANT_ITEM_LOT_ID)?,
+        vagrant_bonus_ene_drop_item_lot_id: read_i32(
+            row,
+            EQG_OFF_VAGRANT_BONUS_ENE_DROP_ITEM_LOT_ID,
+        )?,
+        basic_price: read_i32(row, EQG_OFF_BASIC_PRICE)?,
+        sell_value: read_i32(row, EQG_OFF_SELL_VALUE)?,
+        disable_use_at_out_of_coliseum: (row.get(EQG_OFF_DISABLE_USE_AT_OUT_OF_COLISEUM)?
+            & EQG_BIT_DISABLE_USE_AT_OUT_OF_COLISEUM)
+            != 0,
+    })
+}
+
+/// Convenience: raw row bytes -> decoded synthetic item.
+pub fn decode_synthetic_row(row: &[u8]) -> Option<SyntheticItem> {
+    Some(decode_synthetic(&read_goods_row(row)?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Frozen golden vectors auto-generated from spec-2's `vagrant_codec.py`
+    /// (mirror of tests/codec_vectors_generated.h). (name, ap, low, high).
+    const CODEC_VECTORS: &[(&str, i64, i32, i32)] = &[
+        ("small id", 1000, 0x0000_03E8u32 as i32, 0x0000_0000u32 as i32),
+        ("low32 bit-31 set", 2_147_483_648, 0x8000_0000u32 as i32, 0x0000_0000u32 as i32),
+        ("low32 all-ones (reads as -1)", 4_294_967_295, 0xFFFF_FFFFu32 as i32, 0x0000_0000u32 as i32),
+        ("just over 2^32 (high=1)", 4_294_967_296, 0x0000_0000u32 as i32, 0x0000_0001u32 as i32),
+        ("high bit-31 set", 4_611_686_018_427_392_564, 0x0000_1234u32 as i32, 0x4000_0000u32 as i32),
+        ("plausible AP base+index", 11_000_003_704, 0x8FA6_BC78u32 as i32, 0x0000_0002u32 as i32),
+        ("max int64", 9_223_372_036_854_775_807, 0xFFFF_FFFFu32 as i32, 0x7FFF_FFFFu32 as i32),
+    ];
+
+    #[test]
+    fn recombine_matches_golden_vectors() {
+        for &(name, ap, low, high) in CODEC_VECTORS {
+            let got = recombine_location_id(low, high);
+            assert_eq!(got, ap, "vector {name:?}");
+            // Document where the naive signed widen would diverge.
+            let naive = (low as i64) | ((high as i64) << 32);
+            if low < 0 || high < 0 {
+                assert_ne!(naive, ap, "naive form should corrupt vector {name:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn recombine_inline_cases() {
+        // Mirrors tests.cpp::test_recombine.
+        assert_eq!(recombine_location_id(18_007_000, 0), 18_007_000);
+        assert_eq!(recombine_location_id(101_898, 0), 101_898);
+        assert_eq!(recombine_location_id(0, 2), 8_589_934_592);
+        assert_eq!(recombine_location_id(i32::MIN, 0), 2_147_483_648);
+        assert_eq!(recombine_location_id(i32::MIN, 1), 6_442_450_944);
+        assert_eq!(recombine_location_id(-1, i32::MAX), 0x7FFF_FFFF_FFFF_FFFF);
+    }
+
+    #[test]
+    fn detection_boundaries() {
+        // Mirrors tests.cpp::test_detection.
+        assert!(is_synthetic_goods(CATEGORY_GOODS | 4_000_000));
+        assert!(is_synthetic_goods(CATEGORY_GOODS | 3_780_001));
+        assert!(!is_synthetic_goods(CATEGORY_GOODS | 3_780_000)); // strictly greater
+        assert!(!is_synthetic_goods(CATEGORY_GOODS | 2_220_010)); // max real vanilla goods id
+        // goods-only payoff: other categories never misdetect regardless of magnitude
+        assert!(!is_synthetic_goods(CATEGORY_WEAPON | 99_060_000));
+        assert!(!is_synthetic_goods(CATEGORY_PROTECTOR | 5_330_000));
+        assert!(!is_synthetic_goods(CATEGORY_ACCESSORY | 4_000_000));
+        assert_eq!(item_category_of(CATEGORY_GOODS | 7_004_362), CATEGORY_GOODS);
+        assert_eq!(row_id_of(CATEGORY_GOODS | 7_004_362), 7_004_362);
+    }
+
+    #[test]
+    fn decode_fields() {
+        // Mirrors tests.cpp::test_decode.
+        let local = GoodsRowFields {
+            vagrant_item_lot_id: 18_007_000,
+            vagrant_bonus_ene_drop_item_lot_id: 0,
+            basic_price: 1_000_000,
+            sell_value: 5,
+            disable_use_at_out_of_coliseum: false,
+        };
+        let s = decode_synthetic(&local);
+        assert_eq!(s.ap_location_id, 18_007_000);
+        assert_eq!(s.local_item_id, 1_000_000);
+        assert_eq!(s.local_quantity, 5);
+        assert!(!s.foreign_remove);
+        assert_eq!(decide_pickup(&s), PickupAction::SuppressAndGrant);
+
+        let foreign = GoodsRowFields {
+            vagrant_item_lot_id: 7_004_362,
+            vagrant_bonus_ene_drop_item_lot_id: 0,
+            basic_price: 0,
+            sell_value: 0,
+            disable_use_at_out_of_coliseum: true,
+        };
+        let f = decode_synthetic(&foreign);
+        assert_eq!(f.ap_location_id, 7_004_362);
+        assert_eq!(f.local_item_id, 0);
+        assert!(f.foreign_remove);
+        assert_eq!(decide_pickup(&f), PickupAction::Suppress);
+    }
+
+    fn put_i32(row: &mut [u8], off: usize, v: u32) {
+        row[off..off + 4].copy_from_slice(&v.to_le_bytes());
+    }
+
+    #[test]
+    fn read_raw_row_local_replacement() {
+        // Mirrors row_test.cpp: local-replacement synthetic, bit-31-set low + high=1.
+        let mut row = [0u8; EQG_ROW_SIZE];
+        put_i32(&mut row, EQG_OFF_VAGRANT_ITEM_LOT_ID, 0x8FA0_E6B8);
+        put_i32(&mut row, EQG_OFF_VAGRANT_BONUS_ENE_DROP_ITEM_LOT_ID, 0x0000_0001);
+        put_i32(&mut row, EQG_OFF_BASIC_PRICE, 100_100);
+        put_i32(&mut row, EQG_OFF_SELL_VALUE, 3);
+
+        let fields = read_goods_row(&row).unwrap();
+        assert_eq!(fields.vagrant_item_lot_id, 0x8FA0_E6B8u32 as i32);
+        assert_eq!(fields.basic_price, 100_100);
+        assert_eq!(fields.sell_value, 3);
+        assert!(!fields.disable_use_at_out_of_coliseum);
+
+        let s = decode_synthetic_row(&row).unwrap();
+        assert_eq!(s.ap_location_id, 0x1_8FA0_E6B8); // sign-safe recombine straight off the row
+        assert_eq!(s.local_item_id, 100_100);
+        assert_eq!(s.local_quantity, 3);
+        assert!(!s.foreign_remove);
+    }
+
+    #[test]
+    fn bit5_isolation_and_foreign_remove() {
+        // neighbor bits 4 and 6 set, NOT bit 5 -> foreignRemove false
+        let mut row = [0u8; EQG_ROW_SIZE];
+        row[EQG_OFF_DISABLE_USE_AT_OUT_OF_COLISEUM] = 0x10 | 0x40;
+        assert!(!read_goods_row(&row).unwrap().disable_use_at_out_of_coliseum);
+
+        // bit 5 set, no local item -> foreign remove
+        let mut row = [0u8; EQG_ROW_SIZE];
+        put_i32(&mut row, EQG_OFF_VAGRANT_ITEM_LOT_ID, 7_004_362);
+        row[EQG_OFF_DISABLE_USE_AT_OUT_OF_COLISEUM] = EQG_BIT_DISABLE_USE_AT_OUT_OF_COLISEUM;
+        let g = decode_synthetic_row(&row).unwrap();
+        assert_eq!(g.ap_location_id, 7_004_362);
+        assert!(g.foreign_remove);
+        assert_eq!(g.local_item_id, 0);
+    }
+
+    #[test]
+    fn short_row_is_rejected_not_ub() {
+        // The C++ raw-pointer reader would read OOB; the Rust port returns None.
+        assert!(read_goods_row(&[0u8; 16]).is_none());
+        assert!(read_i32(&[0u8; 3], 0).is_none());
+    }
+}

--- a/crates/er-codec/src/lib.rs
+++ b/crates/er-codec/src/lib.rs
@@ -165,13 +165,48 @@ mod tests {
     /// Frozen golden vectors auto-generated from spec-2's `vagrant_codec.py`
     /// (mirror of tests/codec_vectors_generated.h). (name, ap, low, high).
     const CODEC_VECTORS: &[(&str, i64, i32, i32)] = &[
-        ("small id", 1000, 0x0000_03E8u32 as i32, 0x0000_0000u32 as i32),
-        ("low32 bit-31 set", 2_147_483_648, 0x8000_0000u32 as i32, 0x0000_0000u32 as i32),
-        ("low32 all-ones (reads as -1)", 4_294_967_295, 0xFFFF_FFFFu32 as i32, 0x0000_0000u32 as i32),
-        ("just over 2^32 (high=1)", 4_294_967_296, 0x0000_0000u32 as i32, 0x0000_0001u32 as i32),
-        ("high bit-31 set", 4_611_686_018_427_392_564, 0x0000_1234u32 as i32, 0x4000_0000u32 as i32),
-        ("plausible AP base+index", 11_000_003_704, 0x8FA6_BC78u32 as i32, 0x0000_0002u32 as i32),
-        ("max int64", 9_223_372_036_854_775_807, 0xFFFF_FFFFu32 as i32, 0x7FFF_FFFFu32 as i32),
+        (
+            "small id",
+            1000,
+            0x0000_03E8u32 as i32,
+            0x0000_0000u32 as i32,
+        ),
+        (
+            "low32 bit-31 set",
+            2_147_483_648,
+            0x8000_0000u32 as i32,
+            0x0000_0000u32 as i32,
+        ),
+        (
+            "low32 all-ones (reads as -1)",
+            4_294_967_295,
+            0xFFFF_FFFFu32 as i32,
+            0x0000_0000u32 as i32,
+        ),
+        (
+            "just over 2^32 (high=1)",
+            4_294_967_296,
+            0x0000_0000u32 as i32,
+            0x0000_0001u32 as i32,
+        ),
+        (
+            "high bit-31 set",
+            4_611_686_018_427_392_564,
+            0x0000_1234u32 as i32,
+            0x4000_0000u32 as i32,
+        ),
+        (
+            "plausible AP base+index",
+            11_000_003_704,
+            0x8FA6_BC78u32 as i32,
+            0x0000_0002u32 as i32,
+        ),
+        (
+            "max int64",
+            9_223_372_036_854_775_807,
+            0xFFFF_FFFFu32 as i32,
+            0x7FFF_FFFFu32 as i32,
+        ),
     ];
 
     #[test]
@@ -205,7 +240,7 @@ mod tests {
         assert!(is_synthetic_goods(CATEGORY_GOODS | 3_780_001));
         assert!(!is_synthetic_goods(CATEGORY_GOODS | 3_780_000)); // strictly greater
         assert!(!is_synthetic_goods(CATEGORY_GOODS | 2_220_010)); // max real vanilla goods id
-        // goods-only payoff: other categories never misdetect regardless of magnitude
+                                                                  // goods-only payoff: other categories never misdetect regardless of magnitude
         assert!(!is_synthetic_goods(CATEGORY_WEAPON | 99_060_000));
         assert!(!is_synthetic_goods(CATEGORY_PROTECTOR | 5_330_000));
         assert!(!is_synthetic_goods(CATEGORY_ACCESSORY | 4_000_000));
@@ -253,7 +288,11 @@ mod tests {
         // Mirrors row_test.cpp: local-replacement synthetic, bit-31-set low + high=1.
         let mut row = [0u8; EQG_ROW_SIZE];
         put_i32(&mut row, EQG_OFF_VAGRANT_ITEM_LOT_ID, 0x8FA0_E6B8);
-        put_i32(&mut row, EQG_OFF_VAGRANT_BONUS_ENE_DROP_ITEM_LOT_ID, 0x0000_0001);
+        put_i32(
+            &mut row,
+            EQG_OFF_VAGRANT_BONUS_ENE_DROP_ITEM_LOT_ID,
+            0x0000_0001,
+        );
         put_i32(&mut row, EQG_OFF_BASIC_PRICE, 100_100);
         put_i32(&mut row, EQG_OFF_SELL_VALUE, 3);
 

--- a/crates/er-semver/Cargo.toml
+++ b/crates/er-semver/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "er-semver"
+version = "0.1.0"
+edition = "2021"
+description = "Pre-release-aware node-semver range check for the `versions` lockstep contract. Port of er_version_check.h. Deliberately NOT the `semver` crate: that follows Cargo semantics, which differ from node-semver on the includePrerelease=false prerelease rule that gates this client."
+license = "MIT"
+
+[lints.rust]
+unsafe_code = "forbid"

--- a/crates/er-semver/src/lib.rs
+++ b/crates/er-semver/src/lib.rs
@@ -1,0 +1,257 @@
+//! Pre-release-aware semver range check for the `versions` lockstep contract — Rust port of
+//! `er_version_check.h`.
+//!
+//! The client receives a `versions` range over the AP protocol and must accept/reject its own
+//! contract version against it. Implemented explicitly to node-semver semantics rather than the
+//! `semver` crate, because the load-bearing rule below isn't replicated by Cargo semantics.
+//!
+//! THE RULE (node-semver, `includePrerelease = false`): a version carrying a pre-release tag
+//! satisfies a range only if some comparator in the set shares its exact `[major, minor, patch]`
+//! AND also carries a pre-release. This is why a naive `>=0.1.0` rejects `0.1.0-beta.1`, and why
+//! `includePrerelease` must stay OFF (it would let a future-breaking `0.2.0-beta.1` leak through
+//! `>=0.1.0 <0.2.0`).
+//!
+//! Lockstep phase emits e.g. `">=0.1.0-beta.1 <0.1.0-beta.2"`; graduates to `">=0.1.0 <0.2.0"` at
+//! freeze. Acceptance vectors (verified against node-semver) live in the tests below.
+
+use std::cmp::Ordering;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SemVer {
+    pub major: u64,
+    pub minor: u64,
+    pub patch: u64,
+    /// dot-separated ids; empty => release
+    pub prerelease: Vec<String>,
+}
+
+impl SemVer {
+    pub fn has_pre(&self) -> bool {
+        !self.prerelease.is_empty()
+    }
+    pub fn same_core(&self, o: &SemVer) -> bool {
+        self.major == o.major && self.minor == o.minor && self.patch == o.patch
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParseError(pub String);
+
+impl std::fmt::Display for ParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+impl std::error::Error for ParseError {}
+
+fn split_dots(s: &str) -> Vec<String> {
+    s.split('.').map(|p| p.to_string()).collect()
+}
+
+fn is_numeric_id(s: &str) -> bool {
+    !s.is_empty() && s.bytes().all(|c| c.is_ascii_digit())
+}
+
+pub fn parse_semver(input: &str) -> Result<SemVer, ParseError> {
+    // strip build metadata
+    let s = input.split('+').next().unwrap_or(input);
+
+    let (core, pre) = match s.split_once('-') {
+        Some((core, pre)) => (core, Some(pre)),
+        None => (s, None),
+    };
+    let parts: Vec<&str> = core.split('.').collect();
+    if parts.len() != 3 {
+        return Err(ParseError(format!("bad semver core: {input}")));
+    }
+    let parse_num = |p: &str| -> Result<u64, ParseError> {
+        p.parse::<u64>()
+            .map_err(|_| ParseError(format!("bad semver core: {input}")))
+    };
+    Ok(SemVer {
+        major: parse_num(parts[0])?,
+        minor: parse_num(parts[1])?,
+        patch: parse_num(parts[2])?,
+        prerelease: pre.map(split_dots).unwrap_or_default(),
+    })
+}
+
+/// pre-release precedence (port of `comparePre`).
+fn compare_pre(a: &[String], b: &[String]) -> Ordering {
+    match (a.is_empty(), b.is_empty()) {
+        (true, true) => return Ordering::Equal,
+        (true, false) => return Ordering::Greater, // release > pre-release
+        (false, true) => return Ordering::Less,
+        (false, false) => {}
+    }
+    let n = a.len().min(b.len());
+    for i in 0..n {
+        let (x, y) = (&a[i], &b[i]);
+        let (xn, yn) = (is_numeric_id(x), is_numeric_id(y));
+        if xn && yn {
+            // both numeric; node-semver compares numerically
+            let xv: u64 = x.parse().unwrap();
+            let yv: u64 = y.parse().unwrap();
+            if xv != yv {
+                return xv.cmp(&yv);
+            }
+        } else if xn != yn {
+            // numeric ids rank below alphanumeric
+            return if xn { Ordering::Less } else { Ordering::Greater };
+        } else if x != y {
+            return x.cmp(y);
+        }
+    }
+    // fewer fields ranks lower
+    a.len().cmp(&b.len())
+}
+
+pub fn compare_semver(a: &SemVer, b: &SemVer) -> Ordering {
+    a.major
+        .cmp(&b.major)
+        .then_with(|| a.minor.cmp(&b.minor))
+        .then_with(|| a.patch.cmp(&b.patch))
+        .then_with(|| compare_pre(&a.prerelease, &b.prerelease))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Op {
+    Gte,
+    Gt,
+    Lte,
+    Lt,
+    Eq,
+}
+
+#[derive(Debug, Clone)]
+struct Comparator {
+    op: Op,
+    ver: SemVer,
+}
+
+/// Whitespace-separated comparators (single AND set; no `||`), each `<op><version>`, op in
+/// `{ >=, <=, >, <, = }`; a bare version means `=`. (Port of `parseRange`.)
+fn parse_range(range: &str) -> Result<Vec<Comparator>, ParseError> {
+    let mut out = Vec::new();
+    for tok in range.split_whitespace() {
+        let (op, v) = if let Some(rest) = tok.strip_prefix(">=") {
+            (Op::Gte, rest)
+        } else if let Some(rest) = tok.strip_prefix("<=") {
+            (Op::Lte, rest)
+        } else if let Some(rest) = tok.strip_prefix('>') {
+            (Op::Gt, rest)
+        } else if let Some(rest) = tok.strip_prefix('<') {
+            (Op::Lt, rest)
+        } else if let Some(rest) = tok.strip_prefix('=') {
+            (Op::Eq, rest)
+        } else {
+            (Op::Eq, tok)
+        };
+        out.push(Comparator {
+            op,
+            ver: parse_semver(v)?,
+        });
+    }
+    Ok(out)
+}
+
+fn apply_op(cmp: Ordering, op: &Op) -> bool {
+    match op {
+        Op::Gte => cmp != Ordering::Less,
+        Op::Gt => cmp == Ordering::Greater,
+        Op::Lte => cmp != Ordering::Greater,
+        Op::Lt => cmp == Ordering::Less,
+        Op::Eq => cmp == Ordering::Equal,
+    }
+}
+
+/// node-semver `satisfies`, `includePrerelease = false`. Returns `Err` if either string fails to
+/// parse (the C++ version throws; the connect path should treat a parse error as "reject").
+pub fn version_satisfies(version_str: &str, range_str: &str) -> Result<bool, ParseError> {
+    let v = parse_semver(version_str)?;
+    let comps = parse_range(range_str)?;
+    for c in &comps {
+        if !apply_op(compare_semver(&v, &c.ver), &c.op) {
+            return Ok(false);
+        }
+    }
+    if v.has_pre() {
+        // the pre-release-in-range gate
+        let allowed = comps.iter().any(|c| c.ver.has_pre() && c.ver.same_core(&v));
+        if !allowed {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sat(v: &str, r: &str) -> bool {
+        version_satisfies(v, r).expect("parse")
+    }
+
+    #[test]
+    fn satisfies_vectors_match_node_semver() {
+        // Mirrors tests.cpp::test_versions, verified against node-semver v22.
+        let l = ">=0.1.0-beta.1 <0.1.0-beta.2"; // lockstep now
+        let g = ">=0.1.0 <0.2.0"; // graduated at freeze
+        let n = ">=0.1.0"; // naive trap
+        let cases: &[(&str, &str, bool)] = &[
+            ("0.1.0-beta.1", l, true),
+            ("0.1.0-beta.2", l, false),
+            ("0.1.0", l, false),
+            ("0.2.0-beta.1", l, false),
+            ("0.2.0", l, false),
+            ("0.1.0-beta.1", g, false), // the trap: hardcoding graduated form rejects beta.1
+            ("0.1.0", g, true),
+            ("0.2.0-beta.1", g, false), // future-breaking prerelease does NOT leak
+            ("0.2.0", g, false),
+            ("0.1.0-beta.1", n, false), // gotcha: plain >=0.1.0 rejects matching beta.1
+            ("0.1.0", n, true),
+            ("0.2.0", n, true), // ungated upper bound
+        ];
+        for &(ver, range, expect) in cases {
+            assert_eq!(sat(ver, range), expect, "{ver:?} vs {range:?}");
+        }
+    }
+
+    #[test]
+    fn ordering_rules() {
+        let lt = |a: &str, b: &str| {
+            compare_semver(&parse_semver(a).unwrap(), &parse_semver(b).unwrap())
+        };
+        assert_eq!(lt("0.1.0-beta.1", "0.1.0"), Ordering::Less);
+        assert_eq!(lt("0.1.0-beta.1", "0.1.0-beta.2"), Ordering::Less);
+        assert_eq!(lt("0.1.0", "0.1.0"), Ordering::Equal);
+        // numeric prerelease id ranks below alphanumeric, and numerically among themselves
+        assert_eq!(lt("1.0.0-alpha.1", "1.0.0-alpha.beta"), Ordering::Less);
+        assert_eq!(lt("1.0.0-alpha.2", "1.0.0-alpha.10"), Ordering::Less);
+        // fewer prerelease fields ranks lower
+        assert_eq!(lt("1.0.0-alpha", "1.0.0-alpha.1"), Ordering::Less);
+    }
+
+    #[test]
+    fn current_contract_band() {
+        // The band SYNC-RUNBOOK.md documents as live (>=0.1.0-beta.2 <0.1.0-beta.3): the client's
+        // own contract version must sit inside it, and the neighbours must not.
+        let band = ">=0.1.0-beta.2 <0.1.0-beta.3";
+        assert!(sat("0.1.0-beta.2", band));
+        assert!(!sat("0.1.0-beta.1", band));
+        assert!(!sat("0.1.0-beta.3", band));
+        assert!(!sat("0.1.0", band));
+    }
+
+    #[test]
+    fn build_metadata_is_stripped() {
+        assert!(sat("0.1.0+build.5", ">=0.1.0 <0.2.0"));
+    }
+
+    #[test]
+    fn parse_errors_are_returned_not_panics() {
+        assert!(version_satisfies("not.a.version", ">=0.1.0").is_err());
+        assert!(version_satisfies("0.1.0", ">=not.a.version").is_err());
+    }
+}

--- a/crates/er-semver/src/lib.rs
+++ b/crates/er-semver/src/lib.rs
@@ -97,7 +97,11 @@ fn compare_pre(a: &[String], b: &[String]) -> Ordering {
             }
         } else if xn != yn {
             // numeric ids rank below alphanumeric
-            return if xn { Ordering::Less } else { Ordering::Greater };
+            return if xn {
+                Ordering::Less
+            } else {
+                Ordering::Greater
+            };
         } else if x != y {
             return x.cmp(y);
         }
@@ -220,9 +224,8 @@ mod tests {
 
     #[test]
     fn ordering_rules() {
-        let lt = |a: &str, b: &str| {
-            compare_semver(&parse_semver(a).unwrap(), &parse_semver(b).unwrap())
-        };
+        let lt =
+            |a: &str, b: &str| compare_semver(&parse_semver(a).unwrap(), &parse_semver(b).unwrap());
         assert_eq!(lt("0.1.0-beta.1", "0.1.0"), Ordering::Less);
         assert_eq!(lt("0.1.0-beta.1", "0.1.0-beta.2"), Ordering::Less);
         assert_eq!(lt("0.1.0", "0.1.0"), Ordering::Equal);


### PR DESCRIPTION
Bumps the workspace from archipelago_rs 2.1.1 to 3.0.1, which reports Connect network version 0.6.6 (merged + published upstream). Whole workspace builds clean on it. ER's apworld requires 0.6.6; 0.6.6 is backward-compatible for DS3/Sekiro (no new mandatory client behavior), so this unblocks ER without affecting the others.